### PR TITLE
Fix build badge and add NPM version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dash Platform Protocol JS
 
-[![Build Status](https://travis-ci.com/dashevo/dash-platform.svg?token=Pzix7aqnMuGS9c6BmBz2&branch=v4-ivan-anton)](https://travis-ci.org/dashevo/dash-platform)
+[![Build Status](https://travis-ci.com/dashevo/js-dpp.svg?branch=master)](https://travis-ci.com/dashevo/js-dpp)
 
 > The JavaScript implementation of the [Dash Platform Protocol](http://github.com/dashevo/dpp-spec)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dash Platform Protocol JS
 
 [![Build Status](https://travis-ci.com/dashevo/js-dpp.svg?branch=master)](https://travis-ci.com/dashevo/js-dpp)
+[![NPM version](https://img.shields.io/npm/v/@dashevo/dpp.svg)](https://npmjs.org/package/@dashevo/dpp)
 
 > The JavaScript implementation of the [Dash Platform Protocol](http://github.com/dashevo/dpp-spec)
 


### PR DESCRIPTION
The NPM badge is dependent on an actual publish being done first, so will need #4 merged and to verify the deployment to NPM.