### PR TITLE
Update library name in 2 missed places

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm start
 
 ## Contributing
 
-Feel free to dive in! [Open an issue](https://github.com/dashevo/dash-platform/issues/new) or submit PRs.
+Feel free to dive in! [Open an issue](https://github.com/dashevo/js-dpp/issues/new) or submit PRs.
 
 ## License
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const commonJSConfig = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'DashPlatformProtocol.min.js',
-    library: 'dash-platform',
+    library: 'DashPlatformProtocol',
     libraryTarget: 'umd',
   },
   module: {


### PR DESCRIPTION
* Update link to js-dpp repo issues
    
* Change name of DPP identifier in bundle

If my understanding is correct (I could quite possibly be wrong), the current
name w/a hyphen would not allow this to be used easily in a browser, whereas
DashPlatformProtocol is completely valid as a library name.