### PR TITLE
Update to `0.8.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The JavaScript implementation of the Dash Platform Protocol",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
@shumkov @antouhou It seems NPM does not want to publish `0.8.0` over `0.8.0-dev*` branches somehow. [Telling it is already published](https://travis-ci.com/dashevo/js-dpp/jobs/248168294). Close this PR if I'm missing something.