### PR TITLE
feat: update data trigger errors

### DIFF
--- a/lib/dataTrigger/DataTrigger.js
+++ b/lib/dataTrigger/DataTrigger.js
@@ -47,7 +47,7 @@ class DataTrigger {
     } catch (e) {
       result.addError(
         new DataTriggerExecutionError(
-          this, context, e,
+          this, context.getDataContract(), context.getUserId(), e,
         ),
       );
     }
@@ -56,7 +56,7 @@ class DataTrigger {
       result = new DataTriggerExecutionResult();
       result.addError(
         new DataTriggerInvalidResultError(
-          this, context,
+          this, context.getDataContract(), context.getUserId(),
         ),
       );
     }

--- a/lib/dataTrigger/dpnsTriggers/createDomainDataTrigger.js
+++ b/lib/dataTrigger/dpnsTriggers/createDomainDataTrigger.js
@@ -30,7 +30,10 @@ async function createDomainDataTrigger(document, context) {
   if (fullDomainName.length > MAX_PRINTABLE_DOMAIN_NAME_LENGTH) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'Full domain name length can not be more than 253 characters long',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'Full domain name length can not be more than 253 characters long',
       ),
     );
   }
@@ -40,7 +43,10 @@ async function createDomainDataTrigger(document, context) {
   if (!isHashValidMultihash) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'nameHash is not a valid multihash',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'nameHash is not a valid multihash',
       ),
     );
   }
@@ -48,7 +54,10 @@ async function createDomainDataTrigger(document, context) {
   if (nameHash !== multihash.hash(Buffer.from(fullDomainName)).toString('hex')) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'Document nameHash doesn\'t match actual hash',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'Document nameHash doesn\'t match actual hash',
       ),
     );
   }
@@ -56,7 +65,10 @@ async function createDomainDataTrigger(document, context) {
   if (normalizedLabel !== label.toLowerCase()) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'Normalized label doesn\'t match label',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'Normalized label doesn\'t match label',
       ),
     );
   }
@@ -64,7 +76,10 @@ async function createDomainDataTrigger(document, context) {
   if (context.getUserId() !== records.dashIdentity) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'userId doesn\'t match dashIdentity',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'userId doesn\'t match dashIdentity',
       ),
     );
   }
@@ -73,7 +88,8 @@ async function createDomainDataTrigger(document, context) {
     result.addError(
       new DataTriggerConditionError(
         document,
-        context,
+        context.getDataContract(),
+        context.getUserId(),
         'Parent domain name is not normalized (e.g. contains non-lowercase letter)',
       ),
     );
@@ -91,7 +107,10 @@ async function createDomainDataTrigger(document, context) {
   if (!parentDomain) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'Can\'t find parent domain matching parent hash',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'Can\'t find parent domain matching parent hash',
       ),
     );
   }
@@ -109,7 +128,10 @@ async function createDomainDataTrigger(document, context) {
   if (!preorderDocument) {
     result.addError(
       new DataTriggerConditionError(
-        document, context, 'preorderDocument was not found',
+        document,
+        context.getDataContract(),
+        context.getUserId(),
+        'preorderDocument was not found',
       ),
     );
   }

--- a/lib/dataTrigger/dpnsTriggers/deleteDomainDataTrigger.js
+++ b/lib/dataTrigger/dpnsTriggers/deleteDomainDataTrigger.js
@@ -12,7 +12,14 @@ const DataTriggerConditionError = require('../../errors/DataTriggerConditionErro
 async function deleteDomainDataTrigger(document, context) {
   const result = new DataTriggerExecutionResult();
 
-  result.addError(new DataTriggerConditionError(document, context, 'Delete action is not allowed'));
+  result.addError(
+    new DataTriggerConditionError(
+      document,
+      context.getDataContract(),
+      context.getUserId(),
+      'Delete action is not allowed',
+    ),
+  );
 
   return result;
 }

--- a/lib/dataTrigger/dpnsTriggers/updateDomainDataTrigger.js
+++ b/lib/dataTrigger/dpnsTriggers/updateDomainDataTrigger.js
@@ -12,7 +12,14 @@ const DataTriggerConditionError = require('../../errors/DataTriggerConditionErro
 async function updateDomainDataTrigger(document, context) {
   const result = new DataTriggerExecutionResult();
 
-  result.addError(new DataTriggerConditionError(document, context, 'Update action is not allowed'));
+  result.addError(
+    new DataTriggerConditionError(
+      document,
+      context.getDataContract(),
+      context.getUserId(),
+      'Update action is not allowed',
+    ),
+  );
 
   return result;
 }

--- a/lib/errors/AbstractDataTriggerError.js
+++ b/lib/errors/AbstractDataTriggerError.js
@@ -28,7 +28,7 @@ class AbstractDataTriggerError extends ConsensusError {
   /**
    * Get data trigger user id
    *
-   * @return {DataContract}
+   * @return {string}
    */
   getUserId() {
     return this.userId;

--- a/lib/errors/AbstractDataTriggerError.js
+++ b/lib/errors/AbstractDataTriggerError.js
@@ -6,21 +6,32 @@ const ConsensusError = require('./ConsensusError');
 class AbstractDataTriggerError extends ConsensusError {
   /**
    * @param {string} message
-   * @param {DataTriggerExecutionContext} context
+   * @param {DataContract} dataContract
+   * @param {string} userId
    */
-  constructor(message, context) {
+  constructor(message, dataContract, userId) {
     super(message);
 
-    this.context = context;
+    this.dataContract = dataContract;
+    this.userId = userId;
   }
 
   /**
-   * Get data trigger execution context
+   * Get data trigger data contract
    *
-   * @return {DataTriggerExecutionContext}
+   * @return {DataContract}
    */
-  getContext() {
-    return this.context;
+  getDataContract() {
+    return this.dataContract;
+  }
+
+  /**
+   * Get data trigger user id
+   *
+   * @return {DataContract}
+   */
+  getUserId() {
+    return this.userId;
   }
 }
 

--- a/lib/errors/DataTriggerConditionError.js
+++ b/lib/errors/DataTriggerConditionError.js
@@ -3,11 +3,12 @@ const AbstractDataTriggerError = require('./AbstractDataTriggerError');
 class DataTriggerConditionError extends AbstractDataTriggerError {
   /**
    * @param {Document} document
-   * @param {DataTriggerExecutionContext} context
+   * @param {DataContract} dataContract
+   * @param {string} userId
    * @param {string} message
    */
-  constructor(document, context, message) {
-    super(message, context);
+  constructor(document, dataContract, userId, message) {
+    super(message, dataContract, userId);
 
     this.document = document;
   }

--- a/lib/errors/DataTriggerExecutionError.js
+++ b/lib/errors/DataTriggerExecutionError.js
@@ -3,11 +3,12 @@ const AbstractDataTriggerError = require('./AbstractDataTriggerError');
 class DataTriggerExecutionError extends AbstractDataTriggerError {
   /**
    * @param {DataTrigger} dataTrigger
-   * @param {DataTriggerExecutionContext} context
+   * @param {DataContract} dataContract
+   * @param {string} userId
    * @param {Error} error
    */
-  constructor(dataTrigger, context, error) {
-    super(error.message, context);
+  constructor(dataTrigger, dataContract, userId, error) {
+    super(error.message, dataContract, userId);
 
     this.error = error;
     this.dataTrigger = dataTrigger;

--- a/lib/errors/DataTriggerInvalidResultError.js
+++ b/lib/errors/DataTriggerInvalidResultError.js
@@ -3,10 +3,11 @@ const AbstractDataTriggerError = require('./AbstractDataTriggerError');
 class DataTriggerInvalidResultError extends AbstractDataTriggerError {
   /**
    * @param {DataTrigger} dataTrigger
-   * @param {DataTriggerExecutionContext} context
+   * @param {DataContract} dataContract
+   * @param {string} userId
    */
-  constructor(dataTrigger, context) {
-    super('Data trigger have not returned any result', context);
+  constructor(dataTrigger, dataContract, userId) {
+    super('Data trigger have not returned any result', dataContract, userId);
 
     this.dataTrigger = dataTrigger;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpp",
-  "version": "0.10.0-dev.10",
+  "version": "0.10.0-dev.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpp",
-  "version": "0.10.0-dev.10",
+  "version": "0.10.0-dev.11",
   "description": "The JavaScript implementation of the Dash Platform Protocol",
   "scripts": {
     "lint": "eslint .",

--- a/test/unit/dataTrigger/DataTrigger.spec.js
+++ b/test/unit/dataTrigger/DataTrigger.spec.js
@@ -87,7 +87,7 @@ describe('DataTrigger', () => {
         triggerStub,
       );
 
-      const result = await trigger.execute(context);
+      const result = await trigger.execute(document, context);
 
       expect(result).to.be.an.instanceOf(DataTriggerExecutionResult);
       expect(result.getErrors()[0]).to.be.an.instanceOf(DataTriggerExecutionError);
@@ -104,7 +104,7 @@ describe('DataTrigger', () => {
         triggerStub,
       );
 
-      const result = await trigger.execute(context);
+      const result = await trigger.execute(document, context);
 
       expect(result).to.be.an.instanceOf(DataTriggerExecutionResult);
       expect(result.getErrors()[0]).to.be.an.instanceOf(DataTriggerInvalidResultError);

--- a/test/unit/document/stateTransition/data/validateDocumentsSTDataFactory.spec.js
+++ b/test/unit/document/stateTransition/data/validateDocumentsSTDataFactory.spec.js
@@ -248,7 +248,8 @@ describe('validateDocumentsSTDataFactory', () => {
 
     const dataTriggerExecutionError = new DataTriggerExecutionError(
       documents[0],
-      dataTriggersExecutionContext,
+      dataTriggersExecutionContext.getDataContract(),
+      dataTriggersExecutionContext.getUserId(),
       new Error('error'),
     );
 


### PR DESCRIPTION
Context is to big to pass it whole into GRPC metadata. Let's simplify errors by providing only data we need from the context.