### PR TITLE
feat: ensure all arrays items are defined

### DIFF
--- a/schema/meta/data-contract.json
+++ b/schema/meta/data-contract.json
@@ -70,7 +70,15 @@
           "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
         },
         "additionalItems": {
-          "$ref": "#/definitions/documentSchema"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/documentSchema"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ]
         },
         "items": {
           "oneOf": [
@@ -167,19 +175,52 @@
           "$ref": "#/definitions/documentSchema"
         }
       },
-      "if": {
-        "properties": {
-          "type": {
-            "const": "object"
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "array"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["items"]
           }
         },
-        "not": {
-          "required": ["$ref"]
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "array"
+              },
+              "items": {
+                "type": "array"
+              }
+            },
+            "required": ["type","items"]
+          },
+          "then": {
+            "required": ["additionalItems"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "object"
+              }
+            },
+            "not": {
+              "required": ["$ref"]
+            }
+          },
+          "then": {
+            "required": ["properties", "additionalProperties"]
+          }
         }
-      },
-      "then": {
-        "required": ["properties", "additionalProperties"]
-      },
+      ],
       "additionalProperties": false
     }
   },

--- a/test/integration/dataContract/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validateDataContractFactory.spec.js
@@ -639,6 +639,134 @@ describe('validateDataContractFactory', () => {
         expect(error.dataPath).to.equal('.documents[\'niceDocument\'].properties');
         expect(error.keyword).to.equal('maxProperties');
       });
+
+      it('should have defined items for arrays', () => {
+        rawDataContract.documents.new = {
+          properties: {
+            something: {
+              type: 'array',
+            },
+          },
+          additionalProperties: false,
+        };
+
+        const result = validateDataContract(rawDataContract);
+
+        expectJsonSchemaError(result);
+
+        const [error] = result.getErrors();
+
+        expect(error.dataPath).to.equal('.documents[\'new\'].properties[\'something\']');
+        expect(error.keyword).to.equal('required');
+        expect(error.params.missingProperty).to.equal('.items');
+      });
+
+      it('should not have additionalItems for arrays if items is subschema', () => {
+        rawDataContract.documents.new = {
+          properties: {
+            something: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+          additionalProperties: false,
+        };
+
+        const result = validateDataContract(rawDataContract);
+
+        expectJsonSchemaError(result, 0);
+      });
+
+      it('should have additionalItems for arrays', () => {
+        rawDataContract.documents.new = {
+          properties: {
+            something: {
+              type: 'array',
+              items: [
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'number',
+                },
+              ],
+            },
+          },
+          additionalProperties: false,
+        };
+
+        const result = validateDataContract(rawDataContract);
+
+        expectJsonSchemaError(result);
+
+        const [error] = result.getErrors();
+
+        expect(error.dataPath).to.equal('.documents[\'new\'].properties[\'something\']');
+        expect(error.keyword).to.equal('required');
+        expect(error.params.missingProperty).to.equal('.additionalItems');
+      });
+
+      it('should have additionalItems disabled for arrays', () => {
+        rawDataContract.documents.new = {
+          properties: {
+            something: {
+              type: 'array',
+              items: [
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'number',
+                },
+              ],
+              additionalItems: false,
+            },
+          },
+          additionalProperties: false,
+        };
+
+        const result = validateDataContract(rawDataContract);
+
+        expectJsonSchemaError(result, 0);
+      });
+
+      it('should not have additionalItems enabled for arrays', () => {
+        rawDataContract.documents.new = {
+          properties: {
+            something: {
+              type: 'array',
+              items: [
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'number',
+                },
+              ],
+              additionalItems: true,
+            },
+          },
+          additionalProperties: false,
+        };
+
+        const result = validateDataContract(rawDataContract);
+
+        expectJsonSchemaError(result, 3);
+
+        const [shouldBeAnObjectError, shouldEqualConstant] = result.getErrors();
+
+        expect(shouldBeAnObjectError.dataPath).to.equal(
+          '.documents[\'new\'].properties[\'something\'].additionalItems',
+        );
+        expect(shouldBeAnObjectError.keyword).to.equal('type');
+
+        expect(shouldEqualConstant.dataPath).to.equal(
+          '.documents[\'new\'].properties[\'something\'].additionalItems',
+        );
+        expect(shouldEqualConstant.keyword).to.equal('const');
+      });
     });
   });
 
@@ -985,6 +1113,9 @@ describe('validateDataContractFactory', () => {
         type: 'array',
         items: {
           type: 'array',
+          items: {
+            type: 'string',
+          },
         },
       };
 
@@ -1017,6 +1148,7 @@ describe('validateDataContractFactory', () => {
         }, {
           type: 'number',
         }],
+        additionalItems: false,
       };
 
       const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];


### PR DESCRIPTION
BREAKING CHANGE: `items` and `additionalItems` are required for arrays