### PR TITLE
fix: Brought back identity st create validation and tests

### DIFF
--- a/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateSTStructureFactory.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateSTStructureFactory.js
@@ -1,11 +1,14 @@
-const ValidationResult = require('../../../validation/ValidationResult');
 const IdentityStateTransition = require('./IdentityCreateTransition');
 
+const identityCreateTransitionSchema = require('../../../../schema/identity/stateTransition/identityCreate.json');
+
 /**
+ * @param {JsonSchemaValidator} validator
  * @param {validatePublicKeys} validatePublicKeys
  * @return {validateIdentityCreateST}
  */
 function validateIdentityCreateSTStructureFactory(
+  validator,
   validatePublicKeys,
 ) {
   /**
@@ -22,7 +25,14 @@ function validateIdentityCreateSTStructureFactory(
       rawIdentityStateTransition = identityStateTransition;
     }
 
-    const result = new ValidationResult();
+    const result = validator.validate(
+      identityCreateTransitionSchema,
+      rawIdentityStateTransition,
+    );
+
+    if (!result.isValid()) {
+      return result;
+    }
 
     result.merge(
       validatePublicKeys(rawIdentityStateTransition.publicKeys),

--- a/lib/stateTransition/StateTransitionFacade.js
+++ b/lib/stateTransition/StateTransitionFacade.js
@@ -103,6 +103,7 @@ class StateTransitionFacade {
     );
 
     const validateIdentityCreateSTStructure = validateIdentityCreateSTStructureFactory(
+      validator,
       validatePublicKeys,
     );
 

--- a/test/integration/identity/stateTransition/identityCreateTransition/validateIdentityCreateSTStructureFactory.spec.js
+++ b/test/integration/identity/stateTransition/identityCreateTransition/validateIdentityCreateSTStructureFactory.spec.js
@@ -1,12 +1,20 @@
+const Ajv = require('ajv');
+
 const getIdentityCreateSTFixture = require('../../../../../lib/test/fixtures/getIdentityCreateSTFixture');
 
 const validateIdentityCreateSTStructureFactory = require(
   '../../../../../lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateSTStructureFactory',
 );
 
+const JsonSchemaValidator = require(
+  '../../../../../lib/validation/JsonSchemaValidator',
+);
+
 const IdentityCreateTransition = require(
   '../../../../../lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition',
 );
+
+const { expectJsonSchemaError } = require('../../../../../lib/test/expect/expectError');
 
 const ValidationResult = require('../../../../../lib/validation/ValidationResult');
 
@@ -17,9 +25,13 @@ describe('validateIdentityCreateSTStructureFactory', () => {
   let validatePublicKeysMock;
 
   beforeEach(function beforeEach() {
+    const ajv = new Ajv();
+    const validator = new JsonSchemaValidator(ajv);
+
     validatePublicKeysMock = this.sinonSandbox.stub().returns(new ValidationResult());
 
     validateIdentityCreateST = validateIdentityCreateSTStructureFactory(
+      validator,
       validatePublicKeysMock,
     );
 
@@ -46,5 +58,57 @@ describe('validateIdentityCreateSTStructureFactory', () => {
     expect(validatePublicKeysMock).to.be.calledOnceWithExactly(
       rawStateTransition.publicKeys,
     );
+  });
+
+  describe('publicKeys', () => {
+    it('should be present', () => {
+      rawStateTransition.publicKeys = undefined;
+
+      const result = validateIdentityCreateST(rawStateTransition);
+
+      expectJsonSchemaError(result);
+
+      const [error] = result.getErrors();
+
+      expect(error.dataPath).to.equal('');
+      expect(error.params.missingProperty).to.equal('publicKeys');
+      expect(error.keyword).to.equal('required');
+
+      expect(validatePublicKeysMock).to.not.be.called();
+    });
+
+    it('should not be empty', () => {
+      rawStateTransition.publicKeys = [];
+
+      const result = validateIdentityCreateST(rawStateTransition);
+
+      expectJsonSchemaError(result);
+
+      const [error] = result.getErrors();
+
+      expect(error.keyword).to.equal('minItems');
+      expect(error.dataPath).to.equal('.publicKeys');
+
+      expect(validatePublicKeysMock).to.not.be.called();
+    });
+
+    it('should not have more than 10 items', () => {
+      const [key] = rawStateTransition.publicKeys;
+
+      for (let i = 0; i < 10; i++) {
+        rawStateTransition.publicKeys.push(key);
+      }
+
+      const result = validateIdentityCreateST(rawStateTransition);
+
+      expectJsonSchemaError(result);
+
+      const [error] = result.getErrors();
+
+      expect(error.keyword).to.equal('maxItems');
+      expect(error.dataPath).to.equal('.publicKeys');
+
+      expect(validatePublicKeysMock).to.not.be.called();
+    });
   });
 });


### PR DESCRIPTION
While working on separating validation of identity STs and public keys, identity ST validation and tests were accidentally removed. This PR brings them back