### PR TITLE
fix: conflicting schema ids in AJV cache

### DIFF
--- a/lib/dataContract/enrichDataContractWithBaseSchema.js
+++ b/lib/dataContract/enrichDataContractWithBaseSchema.js
@@ -5,14 +5,14 @@ const DataContract = require('./DataContract');
  *
  * @param {DataContract|RawDataContract} dataContract
  * @param {Object} baseSchema
- * @param {string[]} [excludeBaseDocumentProperties]
+ * @param {string} schemaIdPrefix
  *
- * @return {RawDataContract}
+ * @return {DataContract}
  */
 function enrichDataContractWithBaseSchema(
   dataContract,
   baseSchema,
-  excludeBaseDocumentProperties = [],
+  schemaIdPrefix,
 ) {
   const rawDataContract = (dataContract instanceof DataContract)
     ? dataContract.toJSON()
@@ -38,7 +38,6 @@ function enrichDataContractWithBaseSchema(
     }
 
     Object.keys(baseProperties)
-      .filter((name) => excludeBaseDocumentProperties.indexOf(name) === -1)
       .forEach((name) => {
         clonedDocument.properties[name] = baseProperties[name];
       });
@@ -46,7 +45,10 @@ function enrichDataContractWithBaseSchema(
     baseRequired.forEach((name) => clonedDocument.required.push(name));
   });
 
-  return clonedDataContract;
+  // Add schema $id prefix
+  clonedDataContract.$id = schemaIdPrefix + clonedDataContract.$id;
+
+  return new DataContract(clonedDataContract);
 }
 
 module.exports = enrichDataContractWithBaseSchema;

--- a/lib/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.js
+++ b/lib/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.js
@@ -68,10 +68,12 @@ function validateDocumentsBatchTransitionStructureFactory(
       [ACTIONS.CREATE]: enrichDataContractWithBaseSchema(
         enrichedBaseDataContract,
         createTransitionSchema,
+        'document_create_transition_',
       ),
       [ACTIONS.REPLACE]: enrichDataContractWithBaseSchema(
         enrichedBaseDataContract,
         replaceTransitionSchema,
+        'document_replace_transition_',
       ),
     };
 
@@ -106,11 +108,16 @@ function validateDocumentsBatchTransitionStructureFactory(
       switch (rawDocumentTransition.$action) {
         case ACTIONS.CREATE:
         case ACTIONS.REPLACE: {
-          const documentSchemaRef = dataContract.getDocumentSchemaRef(rawDocumentTransition.$type);
+          // eslint-disable-next-line max-len
+          const enrichedDataContract = enrichedDataContractsByActions[rawDocumentTransition.$action];
+
+          const documentSchemaRef = enrichedDataContract.getDocumentSchemaRef(
+            rawDocumentTransition.$type,
+          );
 
           const additionalSchemas = {
-            [dataContract.getJsonSchemaId()]:
-              enrichedDataContractsByActions[rawDocumentTransition.$action],
+            [enrichedDataContract.getJsonSchemaId()]:
+            enrichedDataContract.toJSON(),
           };
 
           const schemaResult = validator.validate(

--- a/lib/document/validateDocumentFactory.js
+++ b/lib/document/validateDocumentFactory.js
@@ -7,6 +7,7 @@ const InvalidDocumentTypeError = require('../errors/InvalidDocumentTypeError');
 const MissingDocumentTypeError = require('../errors/MissingDocumentTypeError');
 const MismatchDocumentContractIdAndDataContractError = require('../errors/MismatchDocumentContractIdAndDataContractError');
 
+
 /**
  * @param {JsonSchemaValidator} validator
  * @param {enrichDataContractWithBaseSchema} enrichDataContractWithBaseSchema
@@ -46,15 +47,18 @@ module.exports = function validateDocumentFactory(
       return result;
     }
 
-    const documentSchemaRef = dataContract.getDocumentSchemaRef(rawDocument.$type);
+    const documentSchemaRef = dataContract.getDocumentSchemaRef(
+      rawDocument.$type,
+    );
 
     const enrichedDataContract = enrichDataContractWithBaseSchema(
       dataContract,
       baseDocumentSchema,
+      'document_base_',
     );
 
     const additionalSchemas = {
-      [dataContract.getJsonSchemaId()]: enrichedDataContract,
+      [dataContract.getJsonSchemaId()]: enrichedDataContract.toJSON(),
     };
 
     result.merge(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enriching data contracts with various document base schemas we use the same contract schema id that's lead to using previously cached schemas in AJV instead of enriched one.

## What was done?
<!--- Describe your changes in detail -->
Introduced id prefix to `enrichDataContractWithBaseSchema` that now responds with the `DataContract` model instead of raw data. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
