### PR TITLE
fix: schema with key or id already exists

### DIFF
--- a/lib/document/validateDocumentFactory.js
+++ b/lib/document/validateDocumentFactory.js
@@ -47,18 +47,18 @@ module.exports = function validateDocumentFactory(
       return result;
     }
 
-    const documentSchemaRef = dataContract.getDocumentSchemaRef(
-      rawDocument.$type,
-    );
-
     const enrichedDataContract = enrichDataContractWithBaseSchema(
       dataContract,
       baseDocumentSchema,
       'document_base_',
     );
 
+    const documentSchemaRef = enrichedDataContract.getDocumentSchemaRef(
+      rawDocument.$type,
+    );
+
     const additionalSchemas = {
-      [dataContract.getJsonSchemaId()]: enrichedDataContract.toJSON(),
+      [enrichedDataContract.getJsonSchemaId()]: enrichedDataContract.toJSON(),
     };
 
     result.merge(

--- a/test/integration/document/validateDocumentFactory.spec.js
+++ b/test/integration/document/validateDocumentFactory.spec.js
@@ -3,6 +3,8 @@ const Ajv = require('ajv');
 const JsonSchemaValidator = require('../../../lib/validation/JsonSchemaValidator');
 const ValidationResult = require('../../../lib/validation/ValidationResult');
 
+const DataContract = require('../../../lib/dataContract/DataContract');
+
 const validateDocumentFactory = require('../../../lib/document/validateDocumentFactory');
 const enrichDataContractWithBaseSchema = require('../../../lib/dataContract/enrichDataContractWithBaseSchema');
 
@@ -147,7 +149,7 @@ describe('validateDocumentFactory', () => {
       it('should throw an error if getDocumentSchemaRef throws error', function it() {
         const someError = new Error();
 
-        this.sinonSandbox.stub(dataContract, 'getDocumentSchemaRef').throws(someError);
+        this.sinonSandbox.stub(DataContract.prototype, 'getDocumentSchemaRef').throws(someError);
 
         let error;
         try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When calling second-time `validateDocument` it throws `schema with key or id ... already exists` error

## What was done?
<!--- Describe your changes in detail -->
Set correct schema ID to the `additionalSchemas` validator param.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
