### PR TITLE
feat!: encode and decode plain object document instead of JSONs

### DIFF
--- a/lib/document/Document.js
+++ b/lib/document/Document.js
@@ -282,9 +282,9 @@ class Document {
    * @return {Buffer}
    */
   serialize() {
-    const json = this.toJSON();
+    const plainObject = this.toObject();
 
-    return encode(json);
+    return encode(plainObject);
   }
 
   /**

--- a/lib/document/DocumentFactory.js
+++ b/lib/document/DocumentFactory.js
@@ -175,7 +175,7 @@ class DocumentFactory {
       ]);
     }
 
-    return this.createFromJson(rawDocument, options);
+    return this.createFromObject(rawDocument, options);
   }
 
   /**

--- a/lib/stateTransition/AbstractStateTransition.js
+++ b/lib/stateTransition/AbstractStateTransition.js
@@ -115,7 +115,7 @@ class AbstractStateTransition {
    * @return {Buffer}
    */
   serialize(options = {}) {
-    return encode(this.toJSON(options));
+    return encode(this.toObject(options));
   }
 
   /**

--- a/lib/stateTransition/StateTransitionFactory.js
+++ b/lib/stateTransition/StateTransitionFactory.js
@@ -91,7 +91,7 @@ class StateTransitionFactory {
       ]);
     }
 
-    return this.createFromJSON(rawStateTransition, options);
+    return this.createFromObject(rawStateTransition, options);
   }
 }
 

--- a/test/unit/document/DocumentFactory.spec.js
+++ b/test/unit/document/DocumentFactory.spec.js
@@ -218,21 +218,23 @@ describe('DocumentFactory', () => {
 
   describe('createFromSerialized', () => {
     beforeEach(function beforeEach() {
-      this.sinonSandbox.stub(factory, 'createFromJson');
+      this.sinonSandbox.stub(factory, 'createFromObject');
+      // eslint-disable-next-line prefer-destructuring
+      document = documents[8]; // document with binary fields
     });
 
-    it('should return new Data Contract from serialized Contract', async () => {
+    it('should return new Document from serialized one', async () => {
       const serializedDocument = document.serialize();
 
-      decodeMock.returns(rawDocument);
+      decodeMock.returns(document.toObject());
 
-      factory.createFromJson.returns(document);
+      factory.createFromObject.returns(document);
 
       const result = await factory.createFromSerialized(serializedDocument);
 
       expect(result).to.equal(document);
 
-      expect(factory.createFromJson).to.have.been.calledOnceWith(rawDocument);
+      expect(factory.createFromObject).to.have.been.calledOnceWith(document.toObject());
 
       expect(decodeMock).to.have.been.calledOnceWith(serializedDocument);
     });

--- a/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
+++ b/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
@@ -94,7 +94,7 @@ describe('DocumentsBatchTransition', () => {
 
       expect(result).to.equal(serializedStateTransition);
 
-      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toJSON());
+      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toObject());
     });
   });
 
@@ -110,7 +110,7 @@ describe('DocumentsBatchTransition', () => {
 
       expect(result).to.equal(hashedDocument);
 
-      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toJSON());
+      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toObject());
       expect(hashMock).to.have.been.calledOnceWith(serializedDocument);
     });
   });

--- a/test/unit/stateTransition/StateTransitionFactory.spec.js
+++ b/test/unit/stateTransition/StateTransitionFactory.spec.js
@@ -101,7 +101,7 @@ describe('StateTransitionFactory', () => {
 
   describe('createFromSerialized', () => {
     beforeEach(function beforeEach() {
-      this.sinonSandbox.stub(factory, 'createFromJSON');
+      this.sinonSandbox.stub(factory, 'createFromObject');
     });
 
     it('should return new State Transition from serialized contract', async () => {
@@ -109,13 +109,13 @@ describe('StateTransitionFactory', () => {
 
       decodeMock.returns(rawStateTransition);
 
-      factory.createFromJSON.resolves(stateTransition);
+      factory.createFromObject.resolves(stateTransition);
 
       const result = await factory.createFromSerialized(serializedStateTransition);
 
       expect(result).to.equal(stateTransition);
 
-      expect(factory.createFromJSON).to.have.been.calledOnceWith(rawStateTransition);
+      expect(factory.createFromObject).to.have.been.calledOnceWith(rawStateTransition);
 
       expect(decodeMock).to.have.been.calledOnceWith(serializedStateTransition);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We should use plain object for CBOR to correctly encode and decode those

## What was done?
<!--- Describe your changes in detail -->
- passing plain object to `encode` function
- using `createFromObject` in `createFromSerialized`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- `Document#serialize` now returns CBOR encoded plain object instead of CBOR encoded  JSON
- `Document#dash` now will be different

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
