### PR TITLE
fix!: duplicate key error in case of unique index on optional fields

### DIFF
--- a/lib/dataContract/validateDataContractFactory.js
+++ b/lib/dataContract/validateDataContractFactory.js
@@ -11,6 +11,7 @@ const InvalidIndexPropertyTypeError = require('../errors/InvalidIndexPropertyTyp
 const SystemPropertyIndexAlreadyPresentError = require('../errors/SystemPropertyIndexAlreadyPresentError');
 const UniqueIndicesLimitReachedError = require('../errors/UniqueIndicesLimitReachedError');
 const InvalidIndexedPropertyConstraintError = require('../errors/InvalidIndexedPropertyConstraintError');
+const InvalidIndexDefinitionError = require('../errors/InvalidIndexDefinitionError');
 
 const getPropertyDefinitionByPath = require('./getPropertyDefinitionByPath');
 
@@ -221,6 +222,37 @@ module.exports = function validateDataContractFactory(
                 ),
               );
             });
+        });
+      });
+
+    if (!result.isValid()) {
+      return result;
+    }
+
+    Object.entries(enrichedDataContract.documents).filter(([, documentSchema]) => (
+      Object.prototype.hasOwnProperty.call(documentSchema, 'indices')
+    ))
+      .forEach(([documentType, documentSchema]) => {
+        documentSchema.indices.forEach((indexDefinition) => {
+          if (indexDefinition.unique) {
+            const indexPropertyNames = indexDefinition.properties
+              .map((property) => Object.keys(property)[0]);
+
+            // Make sure that compound unique indices contain all fields
+            if (indexPropertyNames.length > 1) {
+              const requiredFields = documentSchema.required || [];
+              const allAreRequired = indexPropertyNames
+                .every((propertyName) => requiredFields.includes(propertyName));
+              const allAreNotRequired = indexPropertyNames
+                .every((propertyName) => !requiredFields.includes(propertyName));
+
+              if (!allAreRequired && !allAreNotRequired) {
+                result.addError(
+                  new InvalidIndexDefinitionError(documentType, indexDefinition),
+                );
+              }
+            }
+          }
         });
       });
 

--- a/lib/dataContract/validateDataContractFactory.js
+++ b/lib/dataContract/validateDataContractFactory.js
@@ -15,7 +15,7 @@ const InvalidCompoundIndexError = require('../errors/InvalidCompoundIndexError')
 
 const getPropertyDefinitionByPath = require('./getPropertyDefinitionByPath');
 
-const systemProperties = ['$id', '$ownerId', '$createdAt', '$updatedAt'];
+const allowedSystemProperties = ['$id', '$ownerId', '$createdAt', '$updatedAt'];
 const prebuiltIndices = ['$id'];
 
 const MAX_INDEXED_STRING_PROPERTY_LENGTH = 1024;
@@ -97,6 +97,10 @@ module.exports = function validateDataContractFactory(
         let isUniqueIndexLimitReached = false;
 
         documentSchema.indices.forEach((indexDefinition) => {
+          const indexPropertyNames = indexDefinition.properties
+            .map((property) => Object.keys(property)[0]);
+
+          // Ensure there are no more than 3 unique indices
           if (!isUniqueIndexLimitReached && indexDefinition.unique) {
             uniqueIndexCount++;
 
@@ -110,9 +114,7 @@ module.exports = function validateDataContractFactory(
             }
           }
 
-          const indexPropertyNames = indexDefinition.properties
-            .map((property) => Object.keys(property)[0]);
-
+          // Ensure there are no duplicate system indices
           prebuiltIndices
             .forEach((propertyName) => {
               const isSingleIndex = indexPropertyNames.length === 1
@@ -128,11 +130,40 @@ module.exports = function validateDataContractFactory(
               }
             });
 
-          indexPropertyNames.forEach((propertyName) => {
-            const propertyDefinition = (getPropertyDefinitionByPath(
-              documentSchema, propertyName,
-            ) || {});
+          // Ensure index properties are defined in the document
+          const userDefinedProperties = indexPropertyNames
+            .filter((name) => !allowedSystemProperties.includes(name));
 
+          const propertyDefinitionEntities = userDefinedProperties
+            .map((propertyName) => (
+              [
+                propertyName,
+                getPropertyDefinitionByPath(documentSchema, propertyName),
+              ]
+            ), {});
+
+          const undefinedProperties = propertyDefinitionEntities
+            .filter(([, propertyDefinition]) => !propertyDefinition)
+            .map(([propertyName]) => {
+              result.addError(
+                new UndefinedIndexPropertyError(
+                  rawDataContract,
+                  documentType,
+                  indexDefinition,
+                  propertyName,
+                ),
+              );
+
+              return propertyName;
+            });
+
+          // Skip further validation if there are undefined properties
+          if (undefinedProperties.length > 0) {
+            return;
+          }
+
+          // Validate indexed property definitions
+          propertyDefinitionEntities.forEach(([propertyName, propertyDefinition]) => {
             const { type: propertyType } = propertyDefinition;
 
             let invalidPropertyType;
@@ -190,43 +221,6 @@ module.exports = function validateDataContractFactory(
             }
           });
 
-          const indicesFingerprint = JSON.stringify(indexDefinition.properties);
-
-          // Ensure index definition uniqueness
-          if (indicesFingerprints.includes(indicesFingerprint)) {
-            result.addError(
-              new DuplicateIndexError(
-                rawDataContract,
-                documentType,
-                indexDefinition,
-              ),
-            );
-          }
-
-          indicesFingerprints.push(indicesFingerprint);
-
-          // Ensure index properties definition
-          const userDefinedProperties = indexPropertyNames
-            .filter((name) => systemProperties.indexOf(name) === -1);
-
-          userDefinedProperties.filter((propertyName) => (
-            !getPropertyDefinitionByPath(documentSchema, propertyName)
-          ))
-            .forEach((undefinedPropertyName) => {
-              result.addError(
-                new UndefinedIndexPropertyError(
-                  rawDataContract,
-                  documentType,
-                  indexDefinition,
-                  undefinedPropertyName,
-                ),
-              );
-            });
-
-          if (result.getErrors().length > 0) {
-            return;
-          }
-
           // Make sure that compound unique indices contain all fields
           if (indexPropertyNames.length > 1) {
             const requiredFields = documentSchema.required || [];
@@ -241,6 +235,21 @@ module.exports = function validateDataContractFactory(
               );
             }
           }
+
+          // Ensure index definition uniqueness
+          const indicesFingerprint = JSON.stringify(indexDefinition.properties);
+
+          if (indicesFingerprints.includes(indicesFingerprint)) {
+            result.addError(
+              new DuplicateIndexError(
+                rawDataContract,
+                documentType,
+                indexDefinition,
+              ),
+            );
+          }
+
+          indicesFingerprints.push(indicesFingerprint);
         });
       });
 

--- a/lib/dataContract/validateDataContractFactory.js
+++ b/lib/dataContract/validateDataContractFactory.js
@@ -11,7 +11,7 @@ const InvalidIndexPropertyTypeError = require('../errors/InvalidIndexPropertyTyp
 const SystemPropertyIndexAlreadyPresentError = require('../errors/SystemPropertyIndexAlreadyPresentError');
 const UniqueIndicesLimitReachedError = require('../errors/UniqueIndicesLimitReachedError');
 const InvalidIndexedPropertyConstraintError = require('../errors/InvalidIndexedPropertyConstraintError');
-const InvalidIndexDefinitionError = require('../errors/InvalidIndexDefinitionError');
+const InvalidCompoundIndexError = require('../errors/InvalidCompoundIndexError');
 
 const getPropertyDefinitionByPath = require('./getPropertyDefinitionByPath');
 
@@ -88,7 +88,7 @@ module.exports = function validateDataContractFactory(
     }
 
     // Validate indices
-    Object.entries(rawDataContract.documents).filter(([, documentSchema]) => (
+    Object.entries(enrichedDataContract.documents).filter(([, documentSchema]) => (
       Object.prototype.hasOwnProperty.call(documentSchema, 'indices')
     ))
       .forEach(([documentType, documentSchema]) => {
@@ -222,35 +222,23 @@ module.exports = function validateDataContractFactory(
                 ),
               );
             });
-        });
-      });
 
-    if (!result.isValid()) {
-      return result;
-    }
+          if (result.getErrors().length > 0) {
+            return;
+          }
 
-    Object.entries(enrichedDataContract.documents).filter(([, documentSchema]) => (
-      Object.prototype.hasOwnProperty.call(documentSchema, 'indices')
-    ))
-      .forEach(([documentType, documentSchema]) => {
-        documentSchema.indices.forEach((indexDefinition) => {
-          if (indexDefinition.unique) {
-            const indexPropertyNames = indexDefinition.properties
-              .map((property) => Object.keys(property)[0]);
+          // Make sure that compound unique indices contain all fields
+          if (indexPropertyNames.length > 1) {
+            const requiredFields = documentSchema.required || [];
+            const allAreRequired = indexPropertyNames
+              .every((propertyName) => requiredFields.includes(propertyName));
+            const allAreNotRequired = indexPropertyNames
+              .every((propertyName) => !requiredFields.includes(propertyName));
 
-            // Make sure that compound unique indices contain all fields
-            if (indexPropertyNames.length > 1) {
-              const requiredFields = documentSchema.required || [];
-              const allAreRequired = indexPropertyNames
-                .every((propertyName) => requiredFields.includes(propertyName));
-              const allAreNotRequired = indexPropertyNames
-                .every((propertyName) => !requiredFields.includes(propertyName));
-
-              if (!allAreRequired && !allAreNotRequired) {
-                result.addError(
-                  new InvalidIndexDefinitionError(documentType, indexDefinition),
-                );
-              }
+            if (!allAreRequired && !allAreNotRequired) {
+              result.addError(
+                new InvalidCompoundIndexError(documentType, indexDefinition),
+              );
             }
           }
         });

--- a/lib/document/stateTransition/validation/data/validateDocumentsBatchTransitionDataFactory.js
+++ b/lib/document/stateTransition/validation/data/validateDocumentsBatchTransitionDataFactory.js
@@ -24,6 +24,7 @@ const BLOCK_TIME_WINDOW_MINUTES = 5;
  * @param {StateRepository} stateRepository
  * @param {fetchDocuments} fetchDocuments
  * @param {validateDocumentsUniquenessByIndices} validateDocumentsUniquenessByIndices
+ * @param {validatePartialCompoundIndices} validatePartialCompoundIndices
  * @param {executeDataTriggers} executeDataTriggers
  * @return {validateDocumentsBatchTransitionData}
  */
@@ -31,6 +32,7 @@ function validateDocumentsBatchTransitionDataFactory(
   stateRepository,
   fetchDocuments,
   validateDocumentsUniquenessByIndices,
+  validatePartialCompoundIndices,
   executeDataTriggers,
 ) {
   /**
@@ -187,6 +189,14 @@ function validateDocumentsBatchTransitionDataFactory(
     if (nonDeleteDocumentTransitions.length > 0) {
       result.merge(
         await validateDocumentsUniquenessByIndices(
+          ownerId,
+          nonDeleteDocumentTransitions,
+          dataContract,
+        ),
+      );
+
+      result.merge(
+        validatePartialCompoundIndices(
           ownerId,
           nonDeleteDocumentTransitions,
           dataContract,

--- a/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
+++ b/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
@@ -19,10 +19,12 @@ function validatePartialCompoundIndices(
 
   documentTransitions.forEach((documentTransition) => {
     const documentSchema = dataContract.getDocumentSchema(documentTransition.getType());
-    const rawDocumentTransition = documentTransition.toObject();
+
     if (!documentSchema.indices) {
       return;
     }
+
+    const rawDocumentTransition = documentTransition.toObject();
 
     documentSchema.indices
       .filter((index) => index.unique && index.properties.length > 1)

--- a/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
+++ b/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
@@ -1,0 +1,59 @@
+const ValidationResult = require('../../../../validation/ValidationResult');
+
+const InconsistentCompoundIndexDataError = require('../../../../errors/InconsistentCompoundIndexDataError');
+
+/**
+ * @typedef validatePartialCompoundIndices
+ * @param {string} ownerId
+ * @param {DocumentCreateTransition[]
+ *         |DocumentReplaceTransition[]} documentTransitions
+ * @param {DataContract} dataContract
+ * @return {ValidationResult}
+ */
+function validatePartialCompoundIndices(
+  ownerId,
+  documentTransitions,
+  dataContract,
+) {
+  const result = new ValidationResult();
+
+  documentTransitions.forEach((documentTransition) => {
+    const documentSchema = dataContract.getDocumentSchema(documentTransition.getType());
+    const rawDocumentTransition = documentTransition.toObject();
+    if (documentSchema.indices) {
+      documentSchema.indices
+        .filter((index) => index.unique && index.properties.length > 1)
+        .forEach((indexDefinition) => {
+          const data = indexDefinition.properties.map((property) => {
+            const [propertyPath] = Object.keys(property);
+
+            if (propertyPath === '$ownerId') {
+              return ownerId;
+            }
+
+            if (propertyPath.startsWith('$')) {
+              return rawDocumentTransition[propertyPath];
+            }
+
+            return documentTransition.get(propertyPath);
+          });
+
+          const allAreDefined = data.every((item) => item !== undefined);
+          const allAreUndefined = data.every((item) => item === undefined);
+
+          const isOk = allAreDefined || allAreUndefined;
+
+          if (!isOk) {
+            result.addError(new InconsistentCompoundIndexDataError(
+              documentTransition.getType(),
+              indexDefinition,
+            ));
+          }
+        });
+    }
+  });
+
+  return result;
+}
+
+module.exports = validatePartialCompoundIndices;

--- a/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
+++ b/lib/document/stateTransition/validation/data/validatePartialCompoundIndices.js
@@ -20,37 +20,39 @@ function validatePartialCompoundIndices(
   documentTransitions.forEach((documentTransition) => {
     const documentSchema = dataContract.getDocumentSchema(documentTransition.getType());
     const rawDocumentTransition = documentTransition.toObject();
-    if (documentSchema.indices) {
-      documentSchema.indices
-        .filter((index) => index.unique && index.properties.length > 1)
-        .forEach((indexDefinition) => {
-          const data = indexDefinition.properties.map((property) => {
-            const [propertyPath] = Object.keys(property);
-
-            if (propertyPath === '$ownerId') {
-              return ownerId;
-            }
-
-            if (propertyPath.startsWith('$')) {
-              return rawDocumentTransition[propertyPath];
-            }
-
-            return documentTransition.get(propertyPath);
-          });
-
-          const allAreDefined = data.every((item) => item !== undefined);
-          const allAreUndefined = data.every((item) => item === undefined);
-
-          const isOk = allAreDefined || allAreUndefined;
-
-          if (!isOk) {
-            result.addError(new InconsistentCompoundIndexDataError(
-              documentTransition.getType(),
-              indexDefinition,
-            ));
-          }
-        });
+    if (!documentSchema.indices) {
+      return;
     }
+
+    documentSchema.indices
+      .filter((index) => index.unique && index.properties.length > 1)
+      .forEach((indexDefinition) => {
+        const data = indexDefinition.properties.map((property) => {
+          const [propertyPath] = Object.keys(property);
+
+          if (propertyPath === '$ownerId') {
+            return ownerId;
+          }
+
+          if (propertyPath.startsWith('$')) {
+            return rawDocumentTransition[propertyPath];
+          }
+
+          return documentTransition.get(propertyPath);
+        });
+
+        const allAreDefined = data.every((item) => item !== undefined);
+        const allAreUndefined = data.every((item) => item === undefined);
+
+        const isOk = allAreDefined || allAreUndefined;
+
+        if (!isOk) {
+          result.addError(new InconsistentCompoundIndexDataError(
+            documentTransition.getType(),
+            indexDefinition,
+          ));
+        }
+      });
   });
 
   return result;

--- a/lib/errors/InconsistentCompoundIndexDataError.js
+++ b/lib/errors/InconsistentCompoundIndexDataError.js
@@ -1,0 +1,33 @@
+const ConsensusError = require('./ConsensusError');
+
+class InconsistentCompoundIndexDataError extends ConsensusError {
+  /**
+   *
+   * @param {string} documentType
+   * @param {Object} indexDefinition
+   */
+  constructor(documentType, indexDefinition) {
+    super('Unique compound index properties are partially set');
+
+    this.documentType = documentType;
+    this.indexDefinition = indexDefinition;
+  }
+
+  /**
+   *
+   * @return {Object}
+   */
+  getIndexDefinition() {
+    return this.indexDefinition;
+  }
+
+  /**
+   *
+   * @return {string}
+   */
+  getDocumentType() {
+    return this.documentType;
+  }
+}
+
+module.exports = InconsistentCompoundIndexDataError;

--- a/lib/errors/InvalidCompoundIndexError.js
+++ b/lib/errors/InvalidCompoundIndexError.js
@@ -1,13 +1,13 @@
 const ConsensusError = require('./ConsensusError');
 
-class InvalidIndexDefinitionError extends ConsensusError {
+class InvalidCompoundIndexError extends ConsensusError {
   /**
    *
    * @param {string} documentType
    * @param {Object} indexDefinition
    */
   constructor(documentType, indexDefinition) {
-    super('Unique compound index properties are partially set');
+    super('All or none of unique compound index properties must be set');
 
     this.documentType = documentType;
     this.indexDefinition = indexDefinition;
@@ -30,4 +30,4 @@ class InvalidIndexDefinitionError extends ConsensusError {
   }
 }
 
-module.exports = InvalidIndexDefinitionError;
+module.exports = InvalidCompoundIndexError;

--- a/lib/errors/InvalidIndexDefinitionError.js
+++ b/lib/errors/InvalidIndexDefinitionError.js
@@ -1,0 +1,33 @@
+const ConsensusError = require('./ConsensusError');
+
+class InvalidIndexDefinitionError extends ConsensusError {
+  /**
+   *
+   * @param {string} documentType
+   * @param {Object} indexDefinition
+   */
+  constructor(documentType, indexDefinition) {
+    super('Unique compound index properties are partially set');
+
+    this.documentType = documentType;
+    this.indexDefinition = indexDefinition;
+  }
+
+  /**
+   *
+   * @return {Object}
+   */
+  getIndexDefinition() {
+    return this.indexDefinition;
+  }
+
+  /**
+   *
+   * @return {string}
+   */
+  getDocumentType() {
+    return this.documentType;
+  }
+}
+
+module.exports = InvalidIndexDefinitionError;

--- a/lib/stateTransition/StateTransitionFacade.js
+++ b/lib/stateTransition/StateTransitionFacade.js
@@ -39,6 +39,7 @@ const findDuplicatesByIndices = require('../document/stateTransition/validation/
 const validateDocumentsBatchTransitionDataFactory = require('../document/stateTransition/validation/data/validateDocumentsBatchTransitionDataFactory');
 const fetchDocumentsFactory = require('../document/stateTransition/validation/data/fetchDocumentsFactory');
 const validateDocumentsUniquenessByIndicesFactory = require('../document/stateTransition/validation/data/validateDocumentsUniquenessByIndicesFactory');
+const validatePartialCompoundIndices = require('../document/stateTransition/validation/data/validatePartialCompoundIndices');
 const getDataTriggersFactory = require('../dataTrigger/getDataTriggersFactory');
 const executeDataTriggersFactory = require('../document/stateTransition/validation/data/executeDataTriggersFactory');
 const validateIdentityExistenceFactory = require('./validation/validateIdentityExistenceFactory');
@@ -190,6 +191,7 @@ class StateTransitionFacade {
       stateRepository,
       fetchDocuments,
       validateDocumentsUniquenessByIndices,
+      validatePartialCompoundIndices,
       executeDataTriggers,
     );
 

--- a/lib/test/fixtures/getDataContractFixture.js
+++ b/lib/test/fixtures/getDataContractFixture.js
@@ -73,7 +73,7 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
           maxLength: 256,
         },
       },
-      required: ['firstName', '$createdAt', '$updatedAt'],
+      required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],
       additionalProperties: false,
     },
     noTimeDocument: {
@@ -120,6 +120,52 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
         },
       },
       required: ['binaryField'],
+      additionalProperties: false,
+    },
+    optionalUniqueIndexedDocument: {
+      properties: {
+        firstName: {
+          type: 'string',
+          maxLength: 256,
+        },
+        lastName: {
+          type: 'string',
+          maxLength: 256,
+        },
+        country: {
+          type: 'string',
+          maxLength: 256,
+        },
+        city: {
+          type: 'string',
+          maxLength: 256,
+        },
+      },
+      indices: [
+        {
+          properties: [
+            { firstName: 'desc' },
+          ],
+          unique: true,
+        },
+        {
+          properties: [
+            { $id: 'asc' },
+            { $ownerId: 'asc' },
+            { firstName: 'asc' },
+            { lastName: 'asc' },
+          ],
+          unique: true,
+        },
+        {
+          properties: [
+            { country: 'asc' },
+            { city: 'asc' },
+          ],
+          unique: true,
+        },
+      ],
+      required: ['firstName', 'lastName'],
       additionalProperties: false,
     },
   };

--- a/lib/test/fixtures/getDocumentsFixture.js
+++ b/lib/test/fixtures/getDocumentsFixture.js
@@ -26,8 +26,9 @@ module.exports = function getDocumentsFixture(dataContract = getDataContractFixt
     factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'Leon', lastName: 'Kennedy' }),
     factory.create(dataContract, ownerId, 'noTimeDocument', { name: 'ImOutOfTime' }),
     factory.create(dataContract, ownerId, 'uniqueDates', { firstName: 'John' }),
-    factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'Bill' }),
+    factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'Bill', lastName: 'Gates' }),
     factory.create(dataContract, ownerId, 'withContentEncoding', { binaryField: crypto.randomBytes(10) }),
+    factory.create(dataContract, ownerId, 'optionalUniqueIndexedDocument', { firstName: 'Jacques-Yves', lastName: 'Cousteau' }),
   ];
 };
 

--- a/test/integration/dataContract/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validateDataContractFactory.spec.js
@@ -19,6 +19,7 @@ const InvalidIndexPropertyTypeError = require('../../../lib/errors/InvalidIndexP
 const SystemPropertyIndexAlreadyPresentError = require('../../../lib/errors/SystemPropertyIndexAlreadyPresentError');
 const UniqueIndicesLimitReachedError = require('../../../lib/errors/UniqueIndicesLimitReachedError');
 const InvalidIndexedPropertyConstraintError = require('../../../lib/errors/InvalidIndexedPropertyConstraintError');
+const InvalidIndexDefinitionError = require('../../../lib/errors/InvalidIndexDefinitionError');
 
 describe('validateDataContractFactory', () => {
   let dataContract;
@@ -1582,5 +1583,19 @@ describe('validateDataContractFactory', () => {
 
     expect(result).to.be.an.instanceOf(ValidationResult);
     expect(result.isValid()).to.be.true();
+  });
+
+  it('should return invalid result if unique compound index contains not all fields', async () => {
+    rawDataContract.documents.optionalUniqueIndexedDocument.required.splice(-1);
+    const result = await validateDataContract(rawDataContract);
+
+    expectValidationError(result, InvalidIndexDefinitionError);
+
+    const [error] = result.getErrors();
+
+    expect(error.getIndexDefinition()).to.deep.equal(
+      rawDataContract.documents.optionalUniqueIndexedDocument.indices[1],
+    );
+    expect(error.getDocumentType()).to.equal('optionalUniqueIndexedDocument');
   });
 });

--- a/test/integration/dataContract/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validateDataContractFactory.spec.js
@@ -1361,157 +1361,7 @@ describe('validateDataContractFactory', () => {
         expect(error.getDocumentType()).to.equal('indexedDocument');
       });
 
-      it('should return invalid result if indices has undefined property', async () => {
-        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
-
-        indexDefinition.properties.push({
-          missingProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, UndefinedIndexPropertyError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getPropertyName()).to.equal('missingProperty');
-        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is object', async () => {
-        const propertiesDefinition = rawDataContract.documents.indexedDocument.properties;
-
-        propertiesDefinition.objectProperty = {
-          type: 'object',
-          properties: {
-            something: {
-              type: 'string',
-            },
-          },
-          additionalProperties: false,
-        };
-
-        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
-
-        indexDefinition.properties.push({
-          objectProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getPropertyName()).to.equal('objectProperty');
-        expect(error.getPropertyType()).to.equal('object');
-        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is array of objects', async () => {
-        const propertiesDefinition = rawDataContract.documents.indexedDocument.properties;
-
-        propertiesDefinition.arrayProperty = {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              something: {
-                type: 'string',
-              },
-            },
-            additionalProperties: false,
-          },
-        };
-
-        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
-
-        indexDefinition.properties.push({
-          arrayProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getPropertyName()).to.equal('arrayProperty');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is array of arrays', async () => {
-        const propertiesDefinition = rawDataContract.documents.indexedDocument.properties;
-
-        propertiesDefinition.arrayProperty = {
-          type: 'array',
-          items: {
-            type: 'array',
-            items: {
-              type: 'string',
-            },
-          },
-        };
-
-        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
-
-        indexDefinition.properties.push({
-          arrayProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getPropertyName()).to.equal('arrayProperty');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is array with many item definitions', async () => {
-        const propertiesDefinition = rawDataContract.documents.indexedDocument.properties;
-
-        propertiesDefinition.arrayProperty = {
-          type: 'array',
-          items: [{
-            type: 'string',
-          }, {
-            type: 'number',
-          }],
-          additionalItems: false,
-        };
-
-        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
-
-        indexDefinition.properties.push({
-          arrayProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getPropertyName()).to.equal('arrayProperty');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is a single $id', async () => {
+      it('should return invalid result if index is prebuilt', async () => {
         const indexDefinition = {
           properties: [
             { $id: 'asc' },
@@ -1532,6 +1382,179 @@ describe('validateDataContractFactory', () => {
         expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
         expect(error.getDocumentType()).to.deep.equal('indexedDocument');
         expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if indices has undefined property', async () => {
+        const indexDefinition = rawDataContract.documents.indexedDocument.indices[0];
+
+        indexDefinition.properties.push({
+          missingProperty: 'asc',
+        });
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, UndefinedIndexPropertyError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getPropertyName()).to.equal('missingProperty');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property is object', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+
+        indexedDocumentDefinition.properties.objectProperty = {
+          type: 'object',
+          properties: {
+            something: {
+              type: 'string',
+            },
+          },
+          additionalProperties: false,
+        };
+
+        indexedDocumentDefinition.required.push('objectProperty');
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        indexDefinition.properties.push({
+          objectProperty: 'asc',
+        });
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getPropertyName()).to.equal('objectProperty');
+        expect(error.getPropertyType()).to.equal('object');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property is array of objects', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+
+        indexedDocumentDefinition.properties.arrayProperty = {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              something: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+        };
+
+        indexedDocumentDefinition.required.push('arrayProperty');
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        indexDefinition.properties.push({
+          arrayProperty: 'asc',
+        });
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getPropertyName()).to.equal('arrayProperty');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property is array of arrays', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+
+        indexedDocumentDefinition.properties.arrayProperty = {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        };
+
+        indexedDocumentDefinition.required.push('arrayProperty');
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        indexDefinition.properties.push({
+          arrayProperty: 'asc',
+        });
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getPropertyName()).to.equal('arrayProperty');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property is array with many item definitions', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+
+        indexedDocumentDefinition.properties.arrayProperty = {
+          type: 'array',
+          items: [{
+            type: 'string',
+          }, {
+            type: 'number',
+          }],
+          additionalItems: false,
+        };
+
+        indexedDocumentDefinition.required.push('arrayProperty');
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        indexDefinition.properties.push({
+          arrayProperty: 'asc',
+        });
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getPropertyName()).to.equal('arrayProperty');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if unique compound index contains both required and optional properties', async () => {
+        rawDataContract.documents.optionalUniqueIndexedDocument.required.splice(-1);
+
+        const result = await validateDataContract(rawDataContract);
+
+        expectValidationError(result, InvalidCompoundIndexError);
+
+        const [error] = result.getErrors();
+
+        expect(error.getIndexDefinition()).to.deep.equal(
+          rawDataContract.documents.optionalUniqueIndexedDocument.indices[1],
+        );
+        expect(error.getDocumentType()).to.equal('optionalUniqueIndexedDocument');
       });
     });
   });
@@ -1583,19 +1606,5 @@ describe('validateDataContractFactory', () => {
 
     expect(result).to.be.an.instanceOf(ValidationResult);
     expect(result.isValid()).to.be.true();
-  });
-
-  it('should return invalid result if unique compound index contains not all fields', async () => {
-    rawDataContract.documents.optionalUniqueIndexedDocument.required.splice(-1);
-    const result = await validateDataContract(rawDataContract);
-
-    expectValidationError(result, InvalidCompoundIndexError);
-
-    const [error] = result.getErrors();
-
-    expect(error.getIndexDefinition()).to.deep.equal(
-      rawDataContract.documents.optionalUniqueIndexedDocument.indices[1],
-    );
-    expect(error.getDocumentType()).to.equal('optionalUniqueIndexedDocument');
   });
 });

--- a/test/integration/dataContract/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validateDataContractFactory.spec.js
@@ -19,7 +19,7 @@ const InvalidIndexPropertyTypeError = require('../../../lib/errors/InvalidIndexP
 const SystemPropertyIndexAlreadyPresentError = require('../../../lib/errors/SystemPropertyIndexAlreadyPresentError');
 const UniqueIndicesLimitReachedError = require('../../../lib/errors/UniqueIndicesLimitReachedError');
 const InvalidIndexedPropertyConstraintError = require('../../../lib/errors/InvalidIndexedPropertyConstraintError');
-const InvalidIndexDefinitionError = require('../../../lib/errors/InvalidIndexDefinitionError');
+const InvalidCompoundIndexError = require('../../../lib/errors/InvalidCompoundIndexError');
 
 describe('validateDataContractFactory', () => {
   let dataContract;
@@ -1589,7 +1589,7 @@ describe('validateDataContractFactory', () => {
     rawDataContract.documents.optionalUniqueIndexedDocument.required.splice(-1);
     const result = await validateDataContract(rawDataContract);
 
-    expectValidationError(result, InvalidIndexDefinitionError);
+    expectValidationError(result, InvalidCompoundIndexError);
 
     const [error] = result.getErrors();
 

--- a/test/integration/document/Document.spec.js
+++ b/test/integration/document/Document.spec.js
@@ -11,7 +11,7 @@ describe('Document', () => {
 
   beforeEach(() => {
     dataContract = getDataContractFixture();
-    [document] = getDocumentsFixture(dataContract).slice(-1);
+    [document] = getDocumentsFixture(dataContract).slice(8);
   });
 
   describe('#toJSON', () => {

--- a/test/integration/document/validateDocumentFactory.spec.js
+++ b/test/integration/document/validateDocumentFactory.spec.js
@@ -470,7 +470,7 @@ describe('validateDocumentFactory', () => {
   });
 
   it('return invalid result if binary field exceeds `maxLength`', () => {
-    const [document] = getDocumentsFixture(dataContract).slice(-1);
+    const document = getDocumentsFixture(dataContract)[8];
 
     document.data.binaryField = Buffer.alloc(32);
 

--- a/test/unit/document/stateTransition/data/validatePartialCompoundIndices.spec.js
+++ b/test/unit/document/stateTransition/data/validatePartialCompoundIndices.spec.js
@@ -41,7 +41,7 @@ describe('validatePartialCompoundIndices', () => {
     expect(error.getDocumentType()).to.equal('optionalUniqueIndexedDocument');
   });
 
-  it('should return result if compound index contains no fields', () => {
+  it('should return valid result if compound index contains no fields', () => {
     const document = getDocumentsFixture(dataContract)[8];
     document.setData({ });
 
@@ -57,7 +57,7 @@ describe('validatePartialCompoundIndices', () => {
     expect(result.isValid()).to.be.true();
   });
 
-  it('should return result if compound index contains all fields', () => {
+  it('should return valid result if compound index contains all fields', () => {
     documents = [getDocumentsFixture(dataContract)[8]];
     documentTransitions = getDocumentTransitionsFixture({
       create: documents,

--- a/test/unit/document/stateTransition/data/validatePartialCompoundIndices.spec.js
+++ b/test/unit/document/stateTransition/data/validatePartialCompoundIndices.spec.js
@@ -1,0 +1,71 @@
+const validatePartialCompoundIndices = require('../../../../../lib/document/stateTransition/validation/data/validatePartialCompoundIndices');
+const InconsistentCompoundIndexDataError = require('../../../../../lib/errors/InconsistentCompoundIndexDataError');
+
+const getDocumentsFixture = require('../../../../../lib/test/fixtures/getDocumentsFixture');
+const getContractFixture = require('../../../../../lib/test/fixtures/getDataContractFixture');
+const getDocumentTransitionsFixture = require('../../../../../lib/test/fixtures/getDocumentTransitionsFixture');
+
+const ValidationResult = require('../../../../../lib/validation/ValidationResult');
+const { expectValidationError } = require('../../../../../lib/test/expect/expectError');
+
+describe('validatePartialCompoundIndices', () => {
+  let documents;
+  let documentTransitions;
+  let dataContract;
+  let ownerId;
+
+  beforeEach(() => {
+    dataContract = getContractFixture();
+    ownerId = '5bGvpuiXVW3yK8np1u51Y2LFk2WCvztpa8yYy6VJpguc';
+  });
+
+  it('should return invalid result if compound index contains not all fields', () => {
+    const document = getDocumentsFixture(dataContract)[9];
+    document.set('lastName', undefined);
+
+    documents = [document];
+    documentTransitions = getDocumentTransitionsFixture({
+      create: documents,
+    });
+
+    const result = validatePartialCompoundIndices(ownerId, documentTransitions, dataContract);
+
+    expectValidationError(result, InconsistentCompoundIndexDataError);
+
+    const { optionalUniqueIndexedDocument } = dataContract.getDocuments();
+    const [error] = result.getErrors();
+
+    expect(error.getIndexDefinition()).to.deep.equal(
+      optionalUniqueIndexedDocument.indices[1],
+    );
+    expect(error.getDocumentType()).to.equal('optionalUniqueIndexedDocument');
+  });
+
+  it('should return result if compound index contains no fields', () => {
+    const document = getDocumentsFixture(dataContract)[8];
+    document.setData({ });
+
+    documents = [document];
+
+    documentTransitions = getDocumentTransitionsFixture({
+      create: documents,
+    });
+
+    const result = validatePartialCompoundIndices(ownerId, documentTransitions, dataContract);
+
+    expect(result).to.be.an.instanceOf(ValidationResult);
+    expect(result.isValid()).to.be.true();
+  });
+
+  it('should return result if compound index contains all fields', () => {
+    documents = [getDocumentsFixture(dataContract)[8]];
+    documentTransitions = getDocumentTransitionsFixture({
+      create: documents,
+    });
+
+    const result = validatePartialCompoundIndices(ownerId, documentTransitions, dataContract);
+
+    expect(result).to.be.an.instanceOf(ValidationResult);
+    expect(result.isValid()).to.be.true();
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Duplicate key error in case of unique index on optional fields

## What was done?
<!--- Describe your changes in detail -->
Additional index validators were added

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
A document compound unique index shouldn't contain both required and optional properties.
A document with a compound unique index must contain all indexed properties or non of them. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
