### PR TITLE
fix: `stateTransition.toJSON` throws an error

### DIFF
--- a/test/unit/stateTransition/StateTransitionFactory.spec.js
+++ b/test/unit/stateTransition/StateTransitionFactory.spec.js
@@ -95,6 +95,23 @@ describe('StateTransitionFactory', () => {
         );
       }
     });
+
+
+    it('should throw InvalidStateTransitionError if stateTransition.toJSON throws ConsensusError', async function it() {
+      const error = new ConsensusError('json error');
+
+      stateTransition.toJSON = this.sinonSandbox.stub().throws(error);
+
+      try {
+        await factory.createFromObject(rawStateTransition);
+        expect.fail('Error was not thrown');
+      } catch (e) {
+        expect(e).to.be.an.instanceOf(InvalidStateTransitionError);
+
+        const [innerError] = e.getErrors();
+        expect(innerError).to.be.equal(error);
+      }
+    });
   });
 
   describe('createFromSerialized', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 Creating a new document with an unknown type will throw `InvalidDocumentTypeError` instead of `InvalidStateTransitionError` containing this error.

## What was done?
<!--- Describe your changes in detail -->
The `createFromObject` method was modified to handle consensus errors from the `toJSON` method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
