### PR TITLE
feat!: identity public keys must be unique within particular Identity

### DIFF
--- a/schema/identity/identity.json
+++ b/schema/identity/identity.json
@@ -16,7 +16,8 @@
     "publicKeys": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 100
+      "maxItems": 100,
+      "uniqueItems": true
     },
     "balance": {
       "type": "integer",

--- a/schema/identity/stateTransition/identityCreate.json
+++ b/schema/identity/stateTransition/identityCreate.json
@@ -16,7 +16,8 @@
     "publicKeys": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 10
+      "maxItems": 10,
+      "uniqueItems": true
     }
   },
   "required": [

--- a/test/integration/identity/validation/validateIdentityFactory.spec.js
+++ b/test/integration/identity/validation/validateIdentityFactory.spec.js
@@ -222,6 +222,21 @@ describe('validateIdentityFactory', () => {
       expect(validatePublicKeysMock).to.not.be.called();
     });
 
+    it('should be unique', async () => {
+      rawIdentity.publicKeys.push(rawIdentity.publicKeys[0]);
+
+      const result = validateIdentity(rawIdentity);
+
+      expectJsonSchemaError(result);
+
+      const [error] = result.getErrors();
+
+      expect(error.keyword).to.equal('uniqueItems');
+      expect(error.dataPath).to.equal('.publicKeys');
+
+      expect(validatePublicKeysMock).to.not.be.called();
+    });
+
     it('should throw an error if publicKeys have more than 100 keys', () => {
       const [key] = rawIdentity.publicKeys;
 

--- a/test/integration/stateTransition/validation/validateStateTransitionStructureFactory.spec.js
+++ b/test/integration/stateTransition/validation/validateStateTransitionStructureFactory.spec.js
@@ -871,6 +871,23 @@ describe('validateStateTransitionStructureFactory', () => {
 
       expect(extensionFunctionMock).to.be.calledOnceWith(rawStateTransition);
     });
+
+    it('should be unique', async () => {
+      rawStateTransition.publicKeys.push(rawStateTransition.publicKeys[0]);
+
+      const result = await validateStateTransitionStructure(
+        rawStateTransition,
+      );
+
+      expectJsonSchemaError(result);
+
+      const [error] = result.getErrors();
+
+      expect(error.keyword).to.equal('uniqueItems');
+      expect(error.dataPath).to.equal('.publicKeys');
+
+      expect(extensionFunctionMock).to.not.be.called();
+    });
   });
 
   describe('Identity TopUp Transition', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to make sure that identity and identity create transition do not contain duplicate keys

## What was done?
<!--- Describe your changes in detail -->
uniqueItems keywords were added to identity and identityCreate schemas

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
identity and identityCreate schemas can't contain duplicate public keys anymore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
