### PR TITLE
fix!: base64 pattern allow empty string

### DIFF
--- a/lib/test/fixtures/getDataContractFixture.js
+++ b/lib/test/fixtures/getDataContractFixture.js
@@ -116,7 +116,7 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
           type: 'string',
           contentEncoding: 'base64',
           maxLength: 16,
-          pattern: '^([A-Za-z0-9+/])*$',
+          pattern: '^([A-Za-z0-9+/])+$',
         },
         base58Field: {
           type: 'string',

--- a/schema/dataContract/dataContractMeta.json
+++ b/schema/dataContract/dataContractMeta.json
@@ -187,7 +187,7 @@
                 "properties": {
                   "pattern": {
                     "type": "string",
-                    "const": "^([A-Za-z0-9+/])*$"
+                    "const": "^([A-Za-z0-9+/])+$"
                   }
                 },
                 "required": [

--- a/test/unit/document/Document.spec.js
+++ b/test/unit/document/Document.spec.js
@@ -59,7 +59,7 @@ describe('Document', () => {
                     type: 'string',
                     contentEncoding: 'base64',
                     maxLength: 64,
-                    pattern: '^([A-Za-z0-9+/])*$',
+                    pattern: '^([A-Za-z0-9+/])+$',
                   },
                 },
               },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Base 64 required `pattern` allows an empty string that doesn't make sense since `maxLength` is a required keyword while using the `pattern` keyword.

## What was done?
<!--- Describe your changes in detail -->
Chars length operator for Base 64 content encoding required pattern is changed from `*` to `+`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Base64 now requires a `pattern` keyword equals to `^([A-Za-z0-9+/])+$`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
