### PR TITLE
feat: Identity and DataContract .toObject

### DIFF
--- a/lib/dataContract/DataContract.js
+++ b/lib/dataContract/DataContract.js
@@ -206,6 +206,15 @@ class DataContract {
   }
 
   /**
+   * Return Data Contract as plain object
+   *
+   * @return {RawDataContract}
+   */
+  toObject() {
+    return this.toJSON();
+  }
+
+  /**
    * Return serialized Data Contract
    *
    * @return {Buffer}

--- a/lib/identity/Identity.js
+++ b/lib/identity/Identity.js
@@ -72,6 +72,7 @@ class Identity {
   }
 
   /**
+   * Return Identity as JSON object
    * @return {RawIdentity}
    */
   toJSON() {
@@ -83,6 +84,14 @@ class Identity {
       balance: this.getBalance(),
       revision: this.getRevision(),
     };
+  }
+
+  /**
+   * Return Identity as plain object
+   * @return {RawIdentity}
+   */
+  toObject() {
+    return this.toJSON();
   }
 
   /**

--- a/test/unit/dataContract/DataContract.spec.js
+++ b/test/unit/dataContract/DataContract.spec.js
@@ -274,6 +274,20 @@ describe('DataContract', () => {
     });
   });
 
+  describe('#toObject', () => {
+    it('should return DataContract as plain object', () => {
+      const result = dataContract.toObject();
+
+      expect(result).to.deep.equal({
+        protocolVersion: dataContract.getProtocolVersion(),
+        $id: contractId,
+        $schema: DataContract.DEFAULTS.SCHEMA,
+        ownerId,
+        documents,
+      });
+    });
+  });
+
   describe('#serialize', () => {
     it('should return serialized DataContract', () => {
       const serializedDocument = '123';

--- a/test/unit/identity/Identity.spec.js
+++ b/test/unit/identity/Identity.spec.js
@@ -120,6 +120,14 @@ describe('Identity', () => {
     });
   });
 
+  describe('#toObject', () => {
+    it('should return object representation', () => {
+      const json = identity.toObject();
+
+      expect(json).to.deep.equal(rawIdentity);
+    });
+  });
+
   describe('#getBalance', () => {
     it('should return set identity balance', () => {
       identity.balance = 42;


### PR DESCRIPTION
## Issue being fixed or feature implemented

All of the librairies we provide have a .toObject() method, some of them are being mirrored with a .toJSON() with / without some modification when needed. 
In this case, this PR only alias .toObject in order to provide these feature. 

## What was done?
- feat(Identity): .toObject alias for .toJSON()
- feat(DataContract): .toObject() alias for .toJSON()

## How Has This Been Tested?
Using current test-suite with added unit.

## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
(Actually, we don't have a docsify doc here nor typings :O)

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
