### PR TITLE
feat: `byteArray` JSON Schema keyword

### DIFF
--- a/lib/ajv/keywords/byteArray/addByteArrayKeyword.js
+++ b/lib/ajv/keywords/byteArray/addByteArrayKeyword.js
@@ -1,0 +1,14 @@
+const byteArrayKeyword = require('./byteArray');
+const minBytesLength = require('./minBytesLength');
+const maxBytesLength = require('./maxBytesLength');
+
+/**
+ * @param {Ajv} ajv
+ */
+function addByteArrayKeyword(ajv) {
+  ajv.addKeyword('byteArray', byteArrayKeyword);
+  ajv.addKeyword('minBytesLength', minBytesLength);
+  ajv.addKeyword('maxBytesLength', maxBytesLength);
+}
+
+module.exports = addByteArrayKeyword;

--- a/lib/ajv/keywords/byteArray/byteArray.js
+++ b/lib/ajv/keywords/byteArray/byteArray.js
@@ -1,3 +1,8 @@
+/**
+ * @param {boolean} schema
+ * @param {*} data
+ * @return {boolean}
+ */
 function validate(schema, data) {
   if (!Buffer.isBuffer(data)) {
     validate.errors = [{

--- a/lib/ajv/keywords/byteArray/byteArray.js
+++ b/lib/ajv/keywords/byteArray/byteArray.js
@@ -1,0 +1,23 @@
+function validate(schema, data) {
+  if (!Buffer.isBuffer(data)) {
+    validate.errors = [{
+      keyword: 'byteArray',
+      message: 'should be a byte array',
+    }];
+
+    return false;
+  }
+
+  return true;
+}
+
+const byteArray = {
+  type: 'object',
+  metaSchema: {
+    type: 'boolean',
+    const: true,
+  },
+  validate,
+};
+
+module.exports = byteArray;

--- a/lib/ajv/keywords/byteArray/maxBytesLength.js
+++ b/lib/ajv/keywords/byteArray/maxBytesLength.js
@@ -1,0 +1,27 @@
+function validate(schema, data) {
+  if (data.length > schema) {
+    validate.errors = [{
+      keyword: 'maxBytesLength',
+      message: `should NOT be longer than ${schema} bytes`,
+      params: {
+        limit: schema,
+      },
+    }];
+
+    return false;
+  }
+
+  return true;
+}
+
+const maxBytesLengthKeyword = {
+  type: 'object',
+  dependencies: ['byteArray'],
+  metaSchema: {
+    type: 'integer',
+    minimum: 0,
+  },
+  validate,
+};
+
+module.exports = maxBytesLengthKeyword;

--- a/lib/ajv/keywords/byteArray/maxBytesLength.js
+++ b/lib/ajv/keywords/byteArray/maxBytesLength.js
@@ -1,3 +1,8 @@
+/**
+ * @param {number} schema
+ * @param {Buffer} data
+ * @return {boolean}
+ */
 function validate(schema, data) {
   if (data.length > schema) {
     validate.errors = [{

--- a/lib/ajv/keywords/byteArray/minBytesLength.js
+++ b/lib/ajv/keywords/byteArray/minBytesLength.js
@@ -1,3 +1,8 @@
+/**
+ * @param {number} schema
+ * @param {Buffer} data
+ * @return {boolean}
+ */
 function validate(schema, data) {
   if (data.length < schema) {
     validate.errors = [{

--- a/lib/ajv/keywords/byteArray/minBytesLength.js
+++ b/lib/ajv/keywords/byteArray/minBytesLength.js
@@ -1,0 +1,27 @@
+function validate(schema, data) {
+  if (data.length < schema) {
+    validate.errors = [{
+      keyword: 'minBytesLength',
+      message: `should NOT be shorter than ${schema} bytes`,
+      params: {
+        limit: schema,
+      },
+    }];
+
+    return false;
+  }
+
+  return true;
+}
+
+const minBytesLengthKeyword = {
+  type: 'object',
+  dependencies: ['byteArray'],
+  metaSchema: {
+    type: 'integer',
+    minimum: 0,
+  },
+  validate,
+};
+
+module.exports = minBytesLengthKeyword;

--- a/test/integration/ajv/keywords/byteArray/addByteArrayKeyword.spec.js
+++ b/test/integration/ajv/keywords/byteArray/addByteArrayKeyword.spec.js
@@ -1,0 +1,318 @@
+const Ajv = require('ajv');
+
+const addByteArrayKeyword = require('../../../../../lib/ajv/keywords/byteArray/addByteArrayKeyword');
+const byteArrayKeyword = require('../../../../../lib/ajv/keywords/byteArray/byteArray');
+const minBytesLength = require('../../../../../lib/ajv/keywords/byteArray/minBytesLength');
+const maxBytesLength = require('../../../../../lib/ajv/keywords/byteArray/maxBytesLength');
+
+describe('addByteArrayKeyword', () => {
+  let ajv;
+
+  beforeEach(() => {
+    ajv = new Ajv();
+  });
+
+  it('should add byteArray, minBytesLength and maxBytesLength keywords', () => {
+    addByteArrayKeyword(ajv);
+
+    expect(
+      ajv.getKeyword('byteArray'),
+    ).to.equal(byteArrayKeyword);
+
+    expect(
+      ajv.getKeyword('minBytesLength'),
+    ).to.equal(minBytesLength);
+
+    expect(
+      ajv.getKeyword('maxBytesLength'),
+    ).to.equal(maxBytesLength);
+  });
+
+  describe('byteArray', () => {
+    beforeEach(() => {
+      addByteArrayKeyword(ajv);
+    });
+
+    describe('compilation', () => {
+      it('should be used with object type', () => {
+        const schema = {
+          type: 'string',
+          byteArray: true,
+        };
+
+        ajv.validate(schema, Buffer.alloc(0));
+
+        expect(ajv.errors).to.have.lengthOf(1);
+        expect(ajv.errors[0].keyword).to.equal('type');
+        expect(ajv.errors[0].params.type).to.equal('string');
+      });
+
+      it('should be boolean', () => {
+        const schema = {
+          type: 'object',
+          byteArray: 'something',
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be boolean');
+        }
+      });
+
+      it('should have value of true', () => {
+        const schema = {
+          type: 'object',
+          byteArray: false,
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be equal to constant');
+        }
+      });
+    });
+
+    describe('validation', () => {
+      it('should invalidate everything but Buffer', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+        };
+
+        ajv.validate(schema, { });
+
+        expect(ajv.errors).to.have.lengthOf(1);
+
+        const [error] = ajv.errors;
+
+        expect(error.keyword).to.equal('byteArray');
+        expect(error.message).to.equal('should be a byte array');
+      });
+
+      it('should accept Buffer', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+        };
+
+        const result = ajv.validate(schema, Buffer.alloc(0));
+
+        expect(result).to.be.true();
+      });
+    });
+  });
+
+  describe('minBytesLength', () => {
+    beforeEach(() => {
+      addByteArrayKeyword(ajv);
+    });
+
+    describe('compilation', () => {
+      it('should be used with object type', () => {
+        const schema = {
+          byteArray: true,
+          type: 'string',
+          minBytesLength: 1,
+        };
+
+        ajv.validate(schema, Buffer.alloc(0));
+
+        expect(ajv.errors).to.have.lengthOf(1);
+
+        const [error] = ajv.errors;
+
+        expect(error.keyword).to.equal('type');
+        expect(error.params.type).to.equal('string');
+      });
+
+      it('should be used together with byteArray', () => {
+        const schema = {
+          type: 'object',
+          minBytesLength: 1,
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('parent schema must have all required keywords: byteArray');
+        }
+      });
+
+      it('should be an integer', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          minBytesLength: 'something',
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be integer');
+        }
+      });
+
+      it('should not be less than 0', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          minBytesLength: -1,
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be >= 0');
+        }
+      });
+    });
+
+    describe('validation', () => {
+      it('should invalidate a byte array shorter than specified', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          minBytesLength: 2,
+        };
+
+        ajv.validate(schema, Buffer.alloc(1));
+
+        expect(ajv.errors).to.have.lengthOf(1);
+
+        const [error] = ajv.errors;
+
+        expect(error.keyword).to.equal('minBytesLength');
+        expect(error.message).to.equal('should NOT be shorter than 2 bytes');
+        expect(error.params.limit).to.equal(2);
+      });
+
+      it('should accept byte array longer than specified', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          minBytesLength: 2,
+        };
+
+        const result = ajv.validate(schema, Buffer.alloc(2));
+
+        expect(result).to.be.true();
+      });
+    });
+  });
+
+  describe('maxBytesLength', () => {
+    beforeEach(() => {
+      addByteArrayKeyword(ajv);
+    });
+
+    describe('compilation', () => {
+      it('should be used with object type', () => {
+        const schema = {
+          byteArray: true,
+          type: 'string',
+          maxBytesLength: 1,
+        };
+
+        ajv.validate(schema, Buffer.alloc(0));
+
+        expect(ajv.errors).to.have.lengthOf(1);
+
+        const [error] = ajv.errors;
+
+        expect(error.keyword).to.equal('type');
+        expect(error.params.type).to.equal('string');
+      });
+
+      it('should be used together with byteArray', () => {
+        const schema = {
+          type: 'object',
+          maxBytesLength: 1,
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('parent schema must have all required keywords: byteArray');
+        }
+      });
+
+      it('should be an integer', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          maxBytesLength: 'something',
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be integer');
+        }
+      });
+
+      it('should not be less than 0', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          maxBytesLength: -1,
+        };
+
+        try {
+          ajv.validate(schema, Buffer.alloc(0));
+
+          expect.fail('should fail with keyword schema error');
+        } catch (e) {
+          expect(e.message).to.equal('keyword schema is invalid: data should be >= 0');
+        }
+      });
+    });
+
+    describe('validation', () => {
+      it('should invalidate a byte array shorter than specified', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          maxBytesLength: 2,
+        };
+
+        ajv.validate(schema, Buffer.alloc(3));
+
+        expect(ajv.errors).to.have.lengthOf(1);
+
+        const [error] = ajv.errors;
+
+        expect(error.keyword).to.equal('maxBytesLength');
+        expect(error.message).to.equal('should NOT be longer than 2 bytes');
+        expect(error.params.limit).to.equal(2);
+      });
+
+      it('should accept byte array shorter than specified', () => {
+        const schema = {
+          type: 'object',
+          byteArray: true,
+          maxBytesLength: 2,
+        };
+
+        const result = ajv.validate(schema, Buffer.alloc(1));
+
+        expect(result).to.be.true();
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Definition and validation of binary data pretty complicated and confusing due to using encoded string. In case if a user needs `minLength`/`maxLength` constraints, they should be calculated for result encoded string but not an origin byte array length. Also, during validation, it required to convert raw data to JSON data (encode Buffers to string) that adds additional complexity and slowdown the consensus eventually.

## What was done?
<!--- Describe your changes in detail -->
Added `byteArray`, `minBytesLength`, and `maxBytesLength` keywords to Ajv, so they can be added later to the data contract meta schema and used in other protocol JSON schemas. `minBytesLength` and `maxBytesLenth` are optional and must be used only together with `byteArray` keyword. `byteArray` must be used only with schema type `object`.

### Example:
```json
{
  "properties": {
     "myBinaryData": {
         "type": "object",
         "byteArray": true,
         "maxBytesLength": 3000,
     }
  },
  "additionalProperties": false
}
```

Note: `type` is not required and can be omitted due to `object` is the default type

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With integration test.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
