### PR TITLE
fix: strings passed to StateRepository instead of Buffers

### DIFF
--- a/lib/StateRepositoryInterface.js
+++ b/lib/StateRepositoryInterface.js
@@ -109,7 +109,7 @@
  * @method
  * @name StateRepository#storeIdentityPublicKeyHashes
  * @param {Buffer} identityId
- * @param {string[]} publicKeyHashes
+ * @param {Buffer[]} publicKeyHashes
  * @returns {Promise<void>}
  */
 

--- a/lib/identity/stateTransitions/identityCreateTransition/applyIdentityCreateTransitionFactory.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/applyIdentityCreateTransitionFactory.js
@@ -43,7 +43,7 @@ function applyIdentityCreateTransitionFactory(
       .map((publicKey) => publicKey.hash());
 
     await stateRepository.storeIdentityPublicKeyHashes(
-      identity.getId().toString(),
+      identity.getId(),
       publicKeyHashes,
     );
   }

--- a/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateTransitionDataFactory.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateTransitionDataFactory.js
@@ -32,7 +32,7 @@ function validateIdentityCreateTransitionDataFactory(
 
     // Check if identity with such id already exists
     const identityId = stateTransition.getIdentityId();
-    const identity = await stateRepository.fetchIdentity(identityId.toBuffer());
+    const identity = await stateRepository.fetchIdentity(identityId);
 
     if (identity) {
       result.addError(new IdentityAlreadyExistsError(stateTransition));

--- a/lib/identity/stateTransitions/identityTopUpTransition/applyIdentityTopUpTransitionFactory.js
+++ b/lib/identity/stateTransitions/identityTopUpTransition/applyIdentityTopUpTransitionFactory.js
@@ -28,7 +28,7 @@ function applyIdentityTopUpTransitionFactory(
 
     const identityId = stateTransition.getIdentityId();
 
-    const identity = await stateRepository.fetchIdentity(identityId.toBuffer());
+    const identity = await stateRepository.fetchIdentity(identityId);
     identity.increaseBalance(creditsAmount);
 
     await stateRepository.storeIdentity(identity);

--- a/test/integration/identity/IdentityFacade.spec.js
+++ b/test/integration/identity/IdentityFacade.spec.js
@@ -114,7 +114,7 @@ describe('IdentityFacade', () => {
         .createIdentityTopUpTransition(identity.getId(), lockedOutPoint);
 
       expect(stateTransition).to.be.instanceOf(IdentityTopUpTransition);
-      expect(stateTransition.getIdentityId().toString()).to.be.equal(identity.getId().toString());
+      expect(stateTransition.getIdentityId()).to.be.deep.equal(identity.getId());
       expect(stateTransition.getLockedOutPoint().toBuffer()).to.deep.equal(lockedOutPoint);
     });
   });

--- a/test/unit/identity/stateTransitions/identityCreateTransition/applyIdentityCreateTransitionFactory.spec.js
+++ b/test/unit/identity/stateTransitions/identityCreateTransition/applyIdentityCreateTransitionFactory.spec.js
@@ -58,7 +58,7 @@ describe('applyIdentityCreateTransitionFactory', () => {
       .map((publicKey) => publicKey.hash());
 
     expect(stateRepositoryMock.storeIdentityPublicKeyHashes).to.have.been.calledOnceWithExactly(
-      identity.getId().toString(),
+      identity.getId(),
       publicKeyHashes,
     );
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`StateRepository` methods accept `Buffer` but there are still strings passed. 

## What was done?
<!--- Describe your changes in detail -->
Pass buffers to `StateRepositry` methods.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
