### PR TITLE
refactor: use byteArray in protocol schemas

### DIFF
--- a/lib/DashPlatformProtocol.js
+++ b/lib/DashPlatformProtocol.js
@@ -1,4 +1,4 @@
-const Ajv = require('ajv');
+const createAjv = require('./ajv/createAjv');
 
 const JsonSchemaValidator = require('./validation/JsonSchemaValidator');
 
@@ -23,7 +23,9 @@ class DashPlatformProtocol {
 
     this.jsonSchemaValidator = options.jsonSchemaValidator;
     if (this.jsonSchemaValidator === undefined) {
-      this.jsonSchemaValidator = new JsonSchemaValidator(new Ajv());
+      const ajv = createAjv();
+
+      this.jsonSchemaValidator = new JsonSchemaValidator(ajv);
     }
 
     const skipAssetLockConfirmationValidation = options.identities

--- a/lib/ajv/createAjv.js
+++ b/lib/ajv/createAjv.js
@@ -1,0 +1,16 @@
+const Ajv = require('ajv');
+
+const addByteArrayKeyword = require('./keywords/byteArray/addByteArrayKeyword');
+
+/**
+ * @return {ajv.Ajv}
+ */
+function createAjv() {
+  const ajv = new Ajv();
+
+  addByteArrayKeyword(ajv);
+
+  return ajv;
+}
+
+module.exports = createAjv;

--- a/lib/ajv/keywords/byteArray/addByteArrayKeyword.js
+++ b/lib/ajv/keywords/byteArray/addByteArrayKeyword.js
@@ -3,7 +3,7 @@ const minBytesLength = require('./minBytesLength');
 const maxBytesLength = require('./maxBytesLength');
 
 /**
- * @param {Ajv} ajv
+ * @param {ajv.Ajv} ajv
  */
 function addByteArrayKeyword(ajv) {
   ajv.addKeyword('byteArray', byteArrayKeyword);

--- a/lib/dataContract/DataContract.js
+++ b/lib/dataContract/DataContract.js
@@ -302,13 +302,4 @@ DataContract.DEFAULTS = {
   SCHEMA: 'https://schema.dash.org/dpp-0-4-0/meta/data-contract',
 };
 
-DataContract.ENCODED_PROPERTIES = {
-  $id: {
-    contentEncoding: 'base58',
-  },
-  ownerId: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = DataContract;

--- a/lib/dataContract/stateTransition/DataContractCreateTransition.js
+++ b/lib/dataContract/stateTransition/DataContractCreateTransition.js
@@ -125,11 +125,4 @@ class DataContractCreateTransition extends AbstractStateTransitionIdentitySigned
  * @property {string} entropy
  */
 
-DataContractCreateTransition.ENCODED_PROPERTIES = {
-  ...AbstractStateTransitionIdentitySigned.ENCODED_PROPERTIES,
-  entropy: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = DataContractCreateTransition;

--- a/lib/dataContract/stateTransition/validation/validateDataContractCreateTransitionStructureFactory.js
+++ b/lib/dataContract/stateTransition/validation/validateDataContractCreateTransitionStructureFactory.js
@@ -3,7 +3,6 @@ const DataContractCreateTransition = require('../DataContractCreateTransition');
 const InvalidDataContractEntropyError = require('../../../errors/InvalidDataContractEntropyError');
 
 const InvalidDataContractIdError = require('../../../errors/InvalidDataContractIdError');
-const encodeObjectProperties = require('../../../util/encoding/encodeObjectProperties');
 
 const entropy = require('../../../util/entropy');
 
@@ -30,15 +29,9 @@ function validateDataContractCreateTransitionStructureFactory(
    * @return {ValidationResult}
    */
   async function validateDataContractCreateTransitionStructure(rawStateTransition) {
-    // Validate state transition against JSON Schema
-    const jsonStateTransition = encodeObjectProperties(
-      rawStateTransition,
-      DataContractCreateTransition.ENCODED_PROPERTIES,
-    );
-
     const result = jsonSchemaValidator.validate(
       dataContractCreateTransitionSchema,
-      jsonStateTransition,
+      rawStateTransition,
     );
 
     if (!result.isValid()) {

--- a/lib/dataContract/validateDataContractFactory.js
+++ b/lib/dataContract/validateDataContractFactory.js
@@ -14,7 +14,6 @@ const InvalidIndexedPropertyConstraintError = require('../errors/InvalidIndexedP
 const InvalidCompoundIndexError = require('../errors/InvalidCompoundIndexError');
 
 const getPropertyDefinitionByPath = require('./getPropertyDefinitionByPath');
-const encodeObjectProperties = require('../util/encoding/encodeObjectProperties');
 
 const allowedSystemProperties = ['$id', '$ownerId', '$createdAt', '$updatedAt'];
 const prebuiltIndices = ['$id'];
@@ -40,16 +39,11 @@ module.exports = function validateDataContractFactory(
   async function validateDataContract(rawDataContract) {
     const result = new ValidationResult();
 
-    const jsonDataContract = encodeObjectProperties(
-      rawDataContract,
-      DataContract.ENCODED_PROPERTIES,
-    );
-
     // Validate Data Contract schema
     result.merge(
       jsonSchemaValidator.validate(
         JsonSchemaValidator.SCHEMAS.META.DATA_CONTRACT,
-        jsonDataContract,
+        rawDataContract,
       ),
     );
 

--- a/lib/document/Document.js
+++ b/lib/document/Document.js
@@ -406,16 +406,4 @@ Document.PROTOCOL_VERSION = 0;
 
 Document.SYSTEM_PREFIX = '$';
 
-Document.ENCODED_PROPERTIES = {
-  $id: {
-    contentEncoding: 'base58',
-  },
-  $dataContractId: {
-    contentEncoding: 'base58',
-  },
-  $ownerId: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = Document;

--- a/lib/document/stateTransition/DocumentsBatchTransition.js
+++ b/lib/document/stateTransition/DocumentsBatchTransition.js
@@ -139,11 +139,4 @@ class DocumentsBatchTransition extends AbstractStateTransitionIdentitySigned {
  * } transitions
  */
 
-DocumentsBatchTransition.ENCODED_PROPERTIES = {
-  ...AbstractStateTransitionIdentitySigned.ENCODED_PROPERTIES,
-  ownerId: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = DocumentsBatchTransition;

--- a/lib/document/stateTransition/documentTransition/AbstractDocumentTransition.js
+++ b/lib/document/stateTransition/documentTransition/AbstractDocumentTransition.js
@@ -150,13 +150,4 @@ AbstractDocumentTransition.ACTION_NAMES = {
   DELETE: 'delete',
 };
 
-AbstractDocumentTransition.ENCODED_PROPERTIES = {
-  $id: {
-    contentEncoding: 'base58',
-  },
-  $dataContractId: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = AbstractDocumentTransition;

--- a/lib/document/stateTransition/documentTransition/DocumentCreateTransition.js
+++ b/lib/document/stateTransition/documentTransition/DocumentCreateTransition.js
@@ -170,11 +170,4 @@ class DocumentCreateTransition extends AbstractDocumentTransition {
 
 DocumentCreateTransition.INITIAL_REVISION = 1;
 
-DocumentCreateTransition.ENCODED_PROPERTIES = {
-  ...AbstractDocumentTransition.ENCODED_PROPERTIES,
-  $entropy: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = DocumentCreateTransition;

--- a/lib/document/stateTransition/documentTransition/DocumentDeleteTransition.js
+++ b/lib/document/stateTransition/documentTransition/DocumentDeleteTransition.js
@@ -19,8 +19,4 @@ class DocumentDeleteTransition extends AbstractDocumentTransition {
  * @typedef {JsonDocumentTransition & Object} JsonDocumentDeleteTransition
  */
 
-DocumentDeleteTransition.ENCODED_PROPERTIES = {
-  ...AbstractDocumentTransition.ENCODED_PROPERTIES,
-};
-
 module.exports = DocumentDeleteTransition;

--- a/lib/document/stateTransition/documentTransition/DocumentReplaceTransition.js
+++ b/lib/document/stateTransition/documentTransition/DocumentReplaceTransition.js
@@ -155,8 +155,4 @@ class DocumentReplaceTransition extends AbstractDocumentTransition {
  * @property {number} [$updatedAt]
  */
 
-DocumentReplaceTransition.ENCODED_PROPERTIES = {
-  ...AbstractDocumentTransition.ENCODED_PROPERTIES,
-};
-
 module.exports = DocumentReplaceTransition;

--- a/lib/document/validateDocumentFactory.js
+++ b/lib/document/validateDocumentFactory.js
@@ -1,5 +1,3 @@
-const Document = require('./Document');
-
 const encodeObjectProperties = require('../util/encoding/encodeObjectProperties');
 
 const baseDocumentSchema = require('../../schema/document/documentBase');
@@ -44,12 +42,11 @@ module.exports = function validateDocumentFactory(
       return result;
     }
 
-    const encodedSystemProperties = Document.ENCODED_PROPERTIES;
     const encodedUserProperties = dataContract.getEncodedProperties(rawDocument.$type);
 
     const jsonDocument = encodeObjectProperties(
       rawDocument,
-      { ...encodedSystemProperties, ...encodedUserProperties },
+      encodedUserProperties,
     );
 
     const enrichedDataContract = enrichDataContractWithBaseSchema(

--- a/lib/identity/Identity.js
+++ b/lib/identity/Identity.js
@@ -215,10 +215,4 @@ class Identity {
 
 Identity.PROTOCOL_VERSION = 0;
 
-Identity.ENCODED_PROPERTIES = {
-  id: {
-    contentEncoding: 'base58',
-  },
-};
-
 module.exports = Identity;

--- a/lib/identity/IdentityPublicKey.js
+++ b/lib/identity/IdentityPublicKey.js
@@ -163,10 +163,4 @@ IdentityPublicKey.TYPES = {
   BLS12_381: 1,
 };
 
-IdentityPublicKey.ENCODED_PROPERTIES = {
-  data: {
-    contentEncoding: 'base64',
-  },
-};
-
 module.exports = IdentityPublicKey;

--- a/lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.js
@@ -164,11 +164,4 @@ class IdentityCreateTransition extends AbstractStateTransition {
  * @property {JsonIdentityPublicKey[]} publicKeys
  */
 
-IdentityCreateTransition.ENCODED_PROPERTIES = {
-  ...AbstractStateTransition.ENCODED_PROPERTIES,
-  lockedOutPoint: {
-    contentEncoding: 'base64',
-  },
-};
-
 module.exports = IdentityCreateTransition;

--- a/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateTransitionStructureFactory.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/validateIdentityCreateTransitionStructureFactory.js
@@ -1,7 +1,3 @@
-const IdentityCreateTransition = require('./IdentityCreateTransition');
-
-const encodeObjectProperties = require('../../../util/encoding/encodeObjectProperties');
-
 const identityCreateTransitionSchema = require('../../../../schema/identity/stateTransition/identityCreate');
 
 /**
@@ -20,14 +16,9 @@ function validateIdentityCreateTransitionStructureFactory(
    */
   function validateIdentityCreateTransitionStructure(rawStateTransition) {
     // Validate state transition against JSON Schema
-    const jsonStateTransition = encodeObjectProperties(
-      rawStateTransition,
-      IdentityCreateTransition.ENCODED_PROPERTIES,
-    );
-
     const result = jsonSchemaValidator.validate(
       identityCreateTransitionSchema,
-      jsonStateTransition,
+      rawStateTransition,
     );
 
     if (!result.isValid()) {

--- a/lib/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.js
+++ b/lib/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.js
@@ -134,14 +134,4 @@ class IdentityTopUpTransition extends AbstractStateTransition {
  * @property {string} identityId
  */
 
-IdentityTopUpTransition.ENCODED_PROPERTIES = {
-  ...AbstractStateTransition.ENCODED_PROPERTIES,
-  identityId: {
-    contentEncoding: 'base58',
-  },
-  lockedOutPoint: {
-    contentEncoding: 'base64',
-  },
-};
-
 module.exports = IdentityTopUpTransition;

--- a/lib/identity/stateTransitions/identityTopUpTransition/validateIdentityTopUpTransitionStructureFactory.js
+++ b/lib/identity/stateTransitions/identityTopUpTransition/validateIdentityTopUpTransitionStructureFactory.js
@@ -1,7 +1,3 @@
-const IdentityTopUpTransition = require('./IdentityTopUpTransition');
-
-const encodeObjectProperties = require('../../../util/encoding/encodeObjectProperties');
-
 const identityTopUpTransitionSchema = require('../../../../schema/identity/stateTransition/identityTopUp.json');
 
 /**
@@ -15,15 +11,9 @@ function validateIdentityTopUpTransitionStructureFactory(jsonSchemaValidator) {
    * @return {ValidationResult}
    */
   function validateIdentityTopUpTransitionStructure(rawStateTransition) {
-    // Validate state transition against JSON Schema
-    const jsonStateTransition = encodeObjectProperties(
-      rawStateTransition,
-      IdentityTopUpTransition.ENCODED_PROPERTIES,
-    );
-
     return jsonSchemaValidator.validate(
       identityTopUpTransitionSchema,
-      jsonStateTransition,
+      rawStateTransition,
     );
   }
 

--- a/lib/identity/validation/validateIdentityFactory.js
+++ b/lib/identity/validation/validateIdentityFactory.js
@@ -1,9 +1,5 @@
 const identitySchema = require('../../../schema/identity/identity');
 
-const Identity = require('../Identity');
-
-const encodeObjectProperties = require('../../util/encoding/encodeObjectProperties');
-
 /**
  * @param {JsonSchemaValidator} validator
  * @param {validatePublicKeys} validatePublicKeys
@@ -21,11 +17,9 @@ function validateIdentityFactory(
    * @return {ValidationResult}
    */
   function validateIdentity(rawIdentity) {
-    const jsonIdentity = encodeObjectProperties(rawIdentity, Identity.ENCODED_PROPERTIES);
-
     const result = validator.validate(
       identitySchema,
-      jsonIdentity,
+      rawIdentity,
     );
 
     if (!result.isValid()) {

--- a/lib/identity/validation/validatePublicKeysFactory.js
+++ b/lib/identity/validation/validatePublicKeysFactory.js
@@ -1,12 +1,8 @@
 const { PublicKey } = require('@dashevo/dashcore-lib');
 
-const IdentityPublicKey = require('../IdentityPublicKey');
-
 const ValidationResult = require('../../validation/ValidationResult');
 
 const publicKeySchema = require('../../../schema/identity/publicKey.json');
-
-const encodeObjectProperties = require('../../util/encoding/encodeObjectProperties');
 
 const InvalidIdentityPublicKeyDataError = require(
   '../../errors/InvalidIdentityPublicKeyDataError',
@@ -41,13 +37,8 @@ function validatePublicKeysFactory(validator) {
 
     // Validate public key structure
     rawPublicKeys.forEach((rawPublicKey) => {
-      const jsonPublicKey = encodeObjectProperties(
-        rawPublicKey,
-        IdentityPublicKey.ENCODED_PROPERTIES,
-      );
-
       result.merge(
-        validator.validate(publicKeySchema, jsonPublicKey),
+        validator.validate(publicKeySchema, rawPublicKey),
       );
     });
 

--- a/lib/stateTransition/AbstractStateTransition.js
+++ b/lib/stateTransition/AbstractStateTransition.js
@@ -213,10 +213,4 @@ class AbstractStateTransition {
  * @property {string} [signature]
  */
 
-AbstractStateTransition.ENCODED_PROPERTIES = {
-  signature: {
-    contentEncoding: 'base64',
-  },
-};
-
 module.exports = AbstractStateTransition;

--- a/lib/stateTransition/AbstractStateTransitionIdentitySigned.js
+++ b/lib/stateTransition/AbstractStateTransitionIdentitySigned.js
@@ -145,8 +145,4 @@ class AbstractStateTransitionIdentitySigned extends AbstractStateTransition {
  * @property {string} [signaturePublicKeyId]
  */
 
-AbstractStateTransitionIdentitySigned.ENCODED_PROPERTIES = {
-  ...AbstractStateTransition.ENCODED_PROPERTIES,
-};
-
 module.exports = AbstractStateTransitionIdentitySigned;

--- a/lib/test/fixtures/getDocumentsFixture.js
+++ b/lib/test/fixtures/getDocumentsFixture.js
@@ -19,16 +19,16 @@ module.exports = function getDocumentsFixture(dataContract = getDataContractFixt
   );
 
   return [
-    factory.create(dataContract, ownerId.toBuffer(), 'niceDocument', { name: 'Cutie' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'prettyDocument', { lastName: 'Shiny' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'prettyDocument', { lastName: 'Sweety' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'indexedDocument', { firstName: 'William', lastName: 'Birkin' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'indexedDocument', { firstName: 'Leon', lastName: 'Kennedy' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'noTimeDocument', { name: 'ImOutOfTime' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'uniqueDates', { firstName: 'John' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'indexedDocument', { firstName: 'Bill', lastName: 'Gates' }),
-    factory.create(dataContract, ownerId.toBuffer(), 'withContentEncoding', { base64Field: crypto.randomBytes(10), base58Field: crypto.randomBytes(10) }),
-    factory.create(dataContract, ownerId.toBuffer(), 'optionalUniqueIndexedDocument', { firstName: 'Jacques-Yves', lastName: 'Cousteau' }),
+    factory.create(dataContract, ownerId, 'niceDocument', { name: 'Cutie' }),
+    factory.create(dataContract, ownerId, 'prettyDocument', { lastName: 'Shiny' }),
+    factory.create(dataContract, ownerId, 'prettyDocument', { lastName: 'Sweety' }),
+    factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'William', lastName: 'Birkin' }),
+    factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'Leon', lastName: 'Kennedy' }),
+    factory.create(dataContract, ownerId, 'noTimeDocument', { name: 'ImOutOfTime' }),
+    factory.create(dataContract, ownerId, 'uniqueDates', { firstName: 'John' }),
+    factory.create(dataContract, ownerId, 'indexedDocument', { firstName: 'Bill', lastName: 'Gates' }),
+    factory.create(dataContract, ownerId, 'withContentEncoding', { base64Field: crypto.randomBytes(10), base58Field: crypto.randomBytes(10) }),
+    factory.create(dataContract, ownerId, 'optionalUniqueIndexedDocument', { firstName: 'Jacques-Yves', lastName: 'Cousteau' }),
   ];
 };
 

--- a/lib/test/fixtures/getDpnsContractFixture.js
+++ b/lib/test/fixtures/getDpnsContractFixture.js
@@ -10,5 +10,5 @@ const ownerId = generateRandomId();
  */
 module.exports = function getDataContractFixture() {
   const factory = new DataContractFactory(() => {});
-  return factory.create(ownerId.toBuffer(), dpnsDocuments);
+  return factory.create(ownerId, dpnsDocuments);
 };

--- a/lib/test/fixtures/getDpnsDocumentFixture.js
+++ b/lib/test/fixtures/getDpnsDocumentFixture.js
@@ -23,7 +23,7 @@ function getTopDocumentFixture(options = {}) {
     normalizedParentDomainName: '',
     preorderSalt: crypto.randomBytes(32),
     records: {
-      dashUniqueIdentityId: ownerId.toBuffer(),
+      dashUniqueIdentityId: ownerId,
     },
     subdomainRules: {
       allowSubdomains: true,
@@ -31,7 +31,7 @@ function getTopDocumentFixture(options = {}) {
     ...options,
   };
 
-  return factory.create(dataContract, ownerId.toBuffer(), 'domain', data);
+  return factory.create(dataContract, ownerId, 'domain', data);
 }
 
 /**
@@ -51,7 +51,7 @@ function getParentDocumentFixture(options = {}) {
     normalizedParentDomainName: 'grandparent',
     preorderSalt: crypto.randomBytes(32),
     records: {
-      dashUniqueIdentityId: ownerId.toBuffer(),
+      dashUniqueIdentityId: ownerId,
     },
     subdomainRules: {
       allowSubdomains: false,
@@ -59,7 +59,7 @@ function getParentDocumentFixture(options = {}) {
     ...options,
   };
 
-  return factory.create(dataContract, ownerId.toBuffer(), 'domain', data);
+  return factory.create(dataContract, ownerId, 'domain', data);
 }
 
 /**
@@ -81,7 +81,7 @@ function getChildDocumentFixture(options = {}) {
     normalizedParentDomainName: parentDomainName,
     preorderSalt: crypto.randomBytes(32),
     records: {
-      dashUniqueIdentityId: ownerId.toBuffer(),
+      dashUniqueIdentityId: ownerId,
     },
     subdomainRules: {
       allowSubdomains: false,
@@ -89,7 +89,7 @@ function getChildDocumentFixture(options = {}) {
     ...options,
   };
 
-  return factory.create(dataContract, ownerId.toBuffer(), 'domain', data);
+  return factory.create(dataContract, ownerId, 'domain', data);
 }
 
 module.exports = {

--- a/lib/test/fixtures/getPreorderDocumentFixture.js
+++ b/lib/test/fixtures/getPreorderDocumentFixture.js
@@ -27,12 +27,12 @@ function getPreorderDocumentFixture(options = {}) {
     parentDomainHash: '',
     preorderSalt: entropy.generate(),
     records: {
-      dashIdentity: ownerId.toBuffer(),
+      dashIdentity: ownerId,
     },
     ...options,
   };
 
-  return factory.create(dataContract, ownerId.toBuffer(), 'preorder', data);
+  return factory.create(dataContract, ownerId, 'preorder', data);
 }
 
 module.exports = getPreorderDocumentFixture;

--- a/schema/dataContract/dataContractMeta.json
+++ b/schema/dataContract/dataContractMeta.json
@@ -329,18 +329,16 @@
       "const": "https://schema.dash.org/dpp-0-4-0/meta/data-contract"
     },
     "$id":{
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "ownerId":{
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "documents": {
       "type": "object",

--- a/schema/dataContract/stateTransition/dataContractCreate.json
+++ b/schema/dataContract/stateTransition/dataContractCreate.json
@@ -15,22 +15,20 @@
       "type": "object"
     },
     "entropy": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 26,
-      "maxLength": 35,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 20,
+      "maxBytesLength": 35
     },
     "signaturePublicKeyId": {
       "type": "integer",
       "minimum": 0
     },
     "signature": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 87,
-      "maxLength": 87,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 65,
+      "maxBytesLength": 65
     }
   },
   "additionalProperties": false,

--- a/schema/document/documentBase.json
+++ b/schema/document/documentBase.json
@@ -9,11 +9,10 @@
       "$comment": "Maximum is the latest Document protocol version"
     },
     "$id": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "$type": {
       "type": "string"
@@ -23,18 +22,16 @@
       "minimum": 1
     },
     "$dataContractId": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "$ownerId": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "$createdAt": {
       "type": "integer",

--- a/schema/document/stateTransition/documentTransition/base.json
+++ b/schema/document/stateTransition/documentTransition/base.json
@@ -3,11 +3,10 @@
   "type": "object",
   "properties": {
     "$id": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "$type": {
       "type": "string"
@@ -17,11 +16,10 @@
       "enum": [0, 1, 3]
     },
     "$dataContractId": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     }
   },
   "required": [

--- a/schema/document/stateTransition/documentTransition/create.json
+++ b/schema/document/stateTransition/documentTransition/create.json
@@ -3,11 +3,10 @@
   "type": "object",
   "properties": {
     "$entropy": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 26,
-      "maxLength": 35,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 20,
+      "maxBytesLength": 35
     },
     "$createdAt": {
       "type": "integer",

--- a/schema/document/stateTransition/documentsBatch.json
+++ b/schema/document/stateTransition/documentsBatch.json
@@ -12,11 +12,10 @@
       "const": 1
     },
     "ownerId": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "transitions": {
       "type": "array",
@@ -31,11 +30,10 @@
       "minimum": 0
     },
     "signature": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 87,
-      "maxLength": 87,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 65,
+      "maxBytesLength": 65
     }
   },
   "additionalProperties": false,

--- a/schema/identity/identity.json
+++ b/schema/identity/identity.json
@@ -8,11 +8,10 @@
       "$comment": "Maximum is the latest Identity protocol version"
     },
     "id": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "publicKeys": {
       "type": "array",

--- a/schema/identity/publicKey.json
+++ b/schema/identity/publicKey.json
@@ -10,51 +10,55 @@
     },
     "type": {
       "type": "integer",
-      "enum": [0, 1],
+      "enum": [
+        0,
+        1
+      ],
       "description": "Public key type. 0 - ECDSA Secp256k1, 1 - BLS 12-381",
       "$comment": "It can't be changed after adding a key"
     },
     "data": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "pattern": "^([A-Za-z0-9+/])+$",
-      "description": "Base64-encoded raw public key",
+      "type": "object",
+      "byteArray": true,
+      "description": "Raw public key",
       "$commit": "It must be a valid key of the specified type and unique for the identity. It can’t be changed after adding a key"
     }
   },
   "allOf": [
     {
       "if": {
-         "properties": {
-            "type": {
-              "const": 0
-            }
-         }
+        "properties": {
+          "type": {
+            "const": 0
+          }
+        }
       },
       "then": {
-         "properties": {
-            "data": {
-               "minLength": 44,
-               "maxLength": 44
-            }
-         }
+        "properties": {
+          "data": {
+            "byteArray": true,
+            "minBytesLength": 33,
+            "maxBytesLength": 33
+          }
+        }
       }
     },
     {
       "if": {
-         "properties": {
-            "type": {
-              "const": 1
-            }
-         }
+        "properties": {
+          "type": {
+            "const": 1
+          }
+        }
       },
       "then": {
-         "properties": {
-            "data": {
-               "minLength": 64,
-               "maxLength": 64
-            }
-         }
+        "properties": {
+          "data": {
+            "byteArray": true,
+            "minBytesLength": 48,
+            "maxBytesLength": 48
+          }
+        }
       }
     }
   ],

--- a/schema/identity/stateTransition/identityCreate.json
+++ b/schema/identity/stateTransition/identityCreate.json
@@ -12,11 +12,10 @@
       "const": 2
     },
     "lockedOutPoint": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 48,
-      "maxLength": 48,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 36,
+      "maxBytesLength": 36
     },
     "publicKeys": {
       "type": "array",
@@ -25,11 +24,10 @@
       "uniqueItems": true
     },
     "signature": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 87,
-      "maxLength": 87,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 65,
+      "maxBytesLength": 65
     }
   },
   "additionalProperties": false,

--- a/schema/identity/stateTransition/identityTopUp.json
+++ b/schema/identity/stateTransition/identityTopUp.json
@@ -12,25 +12,22 @@
       "const": 3
     },
     "lockedOutPoint": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 48,
-      "maxLength": 48,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 36,
+      "maxBytesLength": 36
     },
     "identityId": {
-      "type": "string",
-      "contentEncoding": "base58",
-      "minLength": 42,
-      "maxLength": 44,
-      "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "signature": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "minLength": 87,
-      "maxLength": 87,
-      "pattern": "^([A-Za-z0-9+/])+$"
+      "type": "object",
+      "byteArray": true,
+      "minBytesLength": 65,
+      "maxBytesLength": 65
     }
   },
   "additionalProperties": false,

--- a/test/integration/dataContract/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validateDataContractFactory.spec.js
@@ -1,5 +1,6 @@
-const Ajv = require('ajv');
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
+
+const createAjv = require('../../../lib/ajv/createAjv');
 
 const JsonSchemaValidator = require('../../../lib/validation/JsonSchemaValidator');
 
@@ -30,8 +31,7 @@ describe('validateDataContractFactory', () => {
     dataContract = getDataContractFixture();
     rawDataContract = dataContract.toObject();
 
-    const ajv = new Ajv();
-    const jsonSchemaValidator = new JsonSchemaValidator(ajv);
+    const jsonSchemaValidator = new JsonSchemaValidator(createAjv());
 
     const validateDataContractMaxDepth = validateDataContractMaxDepthFactory($RefParser);
 
@@ -154,8 +154,8 @@ describe('validateDataContractFactory', () => {
       expect(error.params.missingProperty).to.equal('ownerId');
     });
 
-    it('should be a string', async () => {
-      rawDataContract.ownerId = 1;
+    it('should be a byte array', async () => {
+      rawDataContract.ownerId = {};
 
       const result = await validateDataContract(rawDataContract);
 
@@ -164,11 +164,11 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.ownerId');
-      expect(error.keyword).to.equal('type');
+      expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should be no less than 42 chars', async () => {
-      rawDataContract.ownerId = '1'.repeat(41);
+    it('should be no less than 32 bytes', async () => {
+      rawDataContract.ownerId = Buffer.alloc(31);
 
       const result = await validateDataContract(rawDataContract);
 
@@ -177,11 +177,11 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.ownerId');
-      expect(error.keyword).to.equal('minLength');
+      expect(error.keyword).to.equal('minBytesLength');
     });
 
-    it('should be no longer than 44 chars', async () => {
-      rawDataContract.ownerId = '1'.repeat(45);
+    it('should be no longer than 32 bytes', async () => {
+      rawDataContract.ownerId = Buffer.alloc(33);
 
       const result = await validateDataContract(rawDataContract);
 
@@ -190,20 +190,7 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.ownerId');
-      expect(error.keyword).to.equal('maxLength');
-    });
-
-    it('should be base58 encoded', async () => {
-      rawDataContract.ownerId = '&'.repeat(44);
-
-      const result = await validateDataContract(rawDataContract);
-
-      expectJsonSchemaError(result);
-
-      const [error] = result.getErrors();
-
-      expect(error.keyword).to.equal('pattern');
-      expect(error.dataPath).to.equal('.ownerId');
+      expect(error.keyword).to.equal('maxBytesLength');
     });
   });
 
@@ -222,8 +209,8 @@ describe('validateDataContractFactory', () => {
       expect(error.params.missingProperty).to.equal('$id');
     });
 
-    it('should be a string', async () => {
-      rawDataContract.$id = 1;
+    it('should be a byte array', async () => {
+      rawDataContract.$id = {};
 
       const result = await validateDataContract(rawDataContract);
 
@@ -232,11 +219,11 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.$id');
-      expect(error.keyword).to.equal('type');
+      expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should be no less than 42 chars', async () => {
-      rawDataContract.$id = '1'.repeat(41);
+    it('should be no less than 32 bytes', async () => {
+      rawDataContract.$id = Buffer.alloc(31);
 
       const result = await validateDataContract(rawDataContract);
 
@@ -245,11 +232,11 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.$id');
-      expect(error.keyword).to.equal('minLength');
+      expect(error.keyword).to.equal('minBytesLength');
     });
 
-    it('should be no longer than 44 chars', async () => {
-      rawDataContract.$id = '1'.repeat(45);
+    it('should be no longer than 32 bytes', async () => {
+      rawDataContract.$id = Buffer.alloc(33);
 
       const result = await validateDataContract(rawDataContract);
 
@@ -258,20 +245,7 @@ describe('validateDataContractFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.$id');
-      expect(error.keyword).to.equal('maxLength');
-    });
-
-    it('should be base58 encoded', async () => {
-      rawDataContract.$id = '&'.repeat(44);
-
-      const result = await validateDataContract(rawDataContract);
-
-      expectJsonSchemaError(result);
-
-      const [error] = result.getErrors();
-
-      expect(error.keyword).to.equal('pattern');
-      expect(error.dataPath).to.equal('.$id');
+      expect(error.keyword).to.equal('maxBytesLength');
     });
   });
 

--- a/test/integration/document/validateDocumentFactory.spec.js
+++ b/test/integration/document/validateDocumentFactory.spec.js
@@ -1,4 +1,4 @@
-const Ajv = require('ajv');
+const createAjv = require('../../../lib/ajv/createAjv');
 
 const JsonSchemaValidator = require('../../../lib/validation/JsonSchemaValidator');
 const ValidationResult = require('../../../lib/validation/ValidationResult');
@@ -31,7 +31,7 @@ describe('validateDocumentFactory', () => {
   let validator;
 
   beforeEach(function beforeEach() {
-    const ajv = new Ajv();
+    const ajv = createAjv();
 
     validator = new JsonSchemaValidator(ajv);
     this.sinonSandbox.spy(validator, 'validate');
@@ -102,19 +102,6 @@ describe('validateDocumentFactory', () => {
         expect(error.dataPath).to.equal('.$protocolVersion');
         expect(error.keyword).to.equal('maximum');
       });
-
-      it('should be base58 encoded', () => {
-        rawDocument.$id = '&'.repeat(44);
-
-        const result = validateDocument(rawDocument, dataContract);
-
-        expectJsonSchemaError(result);
-
-        const [error] = result.getErrors();
-
-        expect(error.keyword).to.equal('pattern');
-        expect(error.dataPath).to.equal('.$id');
-      });
     });
 
     describe('$id', () => {
@@ -132,8 +119,8 @@ describe('validateDocumentFactory', () => {
         expect(error.params.missingProperty).to.equal('$id');
       });
 
-      it('should be a binary (encoded string)', () => {
-        rawDocument.$id = 1;
+      it('should be a byte array', () => {
+        rawDocument.$id = {};
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -142,12 +129,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$id');
-        expect(error.keyword).to.equal('type');
-        expect(error.params.type).to.equal('string');
+        expect(error.keyword).to.equal('byteArray');
       });
 
-      it('should be no less than 42 chars', () => {
-        rawDocument.$id = '1'.repeat(41);
+      it('should be no less than 32 bytes', () => {
+        rawDocument.$id = Buffer.alloc(31);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -156,11 +142,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$id');
-        expect(error.keyword).to.equal('minLength');
+        expect(error.keyword).to.equal('minBytesLength');
       });
 
-      it('should be no longer than 44 chars', () => {
-        rawDocument.$id = '1'.repeat(45);
+      it('should be no longer than 32 bytes', () => {
+        rawDocument.$id = Buffer.alloc(33);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -169,20 +155,7 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$id');
-        expect(error.keyword).to.equal('maxLength');
-      });
-
-      it('should be base58 encoded', () => {
-        rawDocument.$id = '&'.repeat(44);
-
-        const result = validateDocument(rawDocument, dataContract);
-
-        expectJsonSchemaError(result);
-
-        const [error] = result.getErrors();
-
-        expect(error.keyword).to.equal('pattern');
-        expect(error.dataPath).to.equal('.$id');
+        expect(error.keyword).to.equal('maxBytesLength');
       });
     });
 
@@ -305,8 +278,8 @@ describe('validateDocumentFactory', () => {
         expect(error.params.missingProperty).to.equal('$dataContractId');
       });
 
-      it('should be a binary (encoded string)', () => {
-        rawDocument.$dataContractId = 1;
+      it('should be a byte array', () => {
+        rawDocument.$dataContractId = {};
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -315,11 +288,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$dataContractId');
-        expect(error.keyword).to.equal('type');
+        expect(error.keyword).to.equal('byteArray');
       });
 
-      it('should be no less than 42 chars', () => {
-        rawDocument.$dataContractId = '1'.repeat(41);
+      it('should be no less than 32 bytes', () => {
+        rawDocument.$dataContractId = Buffer.alloc(31);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -328,11 +301,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$dataContractId');
-        expect(error.keyword).to.equal('minLength');
+        expect(error.keyword).to.equal('minBytesLength');
       });
 
-      it('should be no longer than 44 chars', () => {
-        rawDocument.$dataContractId = '1'.repeat(45);
+      it('should be no longer than 32 bytes', () => {
+        rawDocument.$dataContractId = Buffer.alloc(33);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -341,20 +314,7 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$dataContractId');
-        expect(error.keyword).to.equal('maxLength');
-      });
-
-      it('should be base58 encoded', () => {
-        rawDocument.$dataContractId = '&'.repeat(44);
-
-        const result = validateDocument(rawDocument, dataContract);
-
-        expectJsonSchemaError(result);
-
-        const [error] = result.getErrors();
-
-        expect(error.keyword).to.equal('pattern');
-        expect(error.dataPath).to.equal('.$dataContractId');
+        expect(error.keyword).to.equal('maxBytesLength');
       });
     });
 
@@ -373,8 +333,8 @@ describe('validateDocumentFactory', () => {
         expect(error.params.missingProperty).to.equal('$ownerId');
       });
 
-      it('should be a string', () => {
-        rawDocument.$ownerId = 1;
+      it('should be a byte array', () => {
+        rawDocument.$ownerId = {};
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -383,11 +343,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$ownerId');
-        expect(error.keyword).to.equal('type');
+        expect(error.keyword).to.equal('byteArray');
       });
 
-      it('should be no less than 42 chars', () => {
-        rawDocument.$ownerId = '1'.repeat(41);
+      it('should be no less than 32 bytes', () => {
+        rawDocument.$ownerId = Buffer.alloc(31);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -396,11 +356,11 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$ownerId');
-        expect(error.keyword).to.equal('minLength');
+        expect(error.keyword).to.equal('minBytesLength');
       });
 
-      it('should be no longer than 44 chars', () => {
-        rawDocument.$ownerId = '1'.repeat(45);
+      it('should be no longer than 32 bytes', () => {
+        rawDocument.$ownerId = Buffer.alloc(33);
 
         const result = validateDocument(rawDocument, dataContract);
 
@@ -409,20 +369,7 @@ describe('validateDocumentFactory', () => {
         const [error] = result.getErrors();
 
         expect(error.dataPath).to.equal('.$ownerId');
-        expect(error.keyword).to.equal('maxLength');
-      });
-
-      it('should be base58 encoded', () => {
-        rawDocument.$ownerId = '&'.repeat(44);
-
-        const result = validateDocument(rawDocument, dataContract);
-
-        expectJsonSchemaError(result);
-
-        const [error] = result.getErrors();
-
-        expect(error.keyword).to.equal('pattern');
-        expect(error.dataPath).to.equal('.$ownerId');
+        expect(error.keyword).to.equal('maxBytesLength');
       });
     });
   });

--- a/test/integration/identity/stateTransition/identityTopUpTransition/validateIdentityTopUpTransitionStructureFactory.spec.js
+++ b/test/integration/identity/stateTransition/identityTopUpTransition/validateIdentityTopUpTransitionStructureFactory.spec.js
@@ -1,4 +1,4 @@
-const Ajv = require('ajv');
+const createAjv = require('../../../../../lib/ajv/createAjv');
 
 const JsonSchemaValidator = require('../../../../../lib/validation/JsonSchemaValidator');
 
@@ -18,7 +18,7 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
   let validateIdentityTopUpTransitionStructure;
 
   beforeEach(() => {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const jsonSchemaValidator = new JsonSchemaValidator(ajv);
 
     validateIdentityTopUpTransitionStructure = validateIdentityTopUpTransitionStructureFactory(
@@ -136,8 +136,8 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       expect(error.keyword).to.equal('required');
     });
 
-    it('should be a binary (encoded string)', async () => {
-      rawStateTransition.lockedOutPoint = 1;
+    it('should be a byte array', async () => {
+      rawStateTransition.lockedOutPoint = {};
 
       const result = await validateIdentityTopUpTransitionStructure(rawStateTransition);
 
@@ -146,12 +146,11 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.lockedOutPoint');
-      expect(error.keyword).to.equal('type');
-      expect(error.params.type).to.equal('string');
+      expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should not be less than 36 bytes (48 characters) in length', async () => {
-      rawStateTransition.lockedOutPoint = '1';
+    it('should not be less than 36 bytes', async () => {
+      rawStateTransition.lockedOutPoint = Buffer.alloc(35);
 
       const result = await validateIdentityTopUpTransitionStructure(
         rawStateTransition,
@@ -161,12 +160,12 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
 
       const [error] = result.getErrors();
 
-      expect(error.keyword).to.equal('minLength');
+      expect(error.keyword).to.equal('minBytesLength');
       expect(error.dataPath).to.equal('.lockedOutPoint');
     });
 
-    it('should not be more than 36 bytes (48 characters) in length', async () => {
-      rawStateTransition.lockedOutPoint = Buffer.alloc(48).toString('base64');
+    it('should not be more than 36 bytes', async () => {
+      rawStateTransition.lockedOutPoint = Buffer.alloc(37);
 
       const result = await validateIdentityTopUpTransitionStructure(
         rawStateTransition,
@@ -176,26 +175,10 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
 
       const [error] = result.getErrors();
 
-      expect(error.keyword).to.equal('maxLength');
-      expect(error.dataPath).to.equal('.lockedOutPoint');
-    });
-
-    it('should be base64 encoded', async () => {
-      rawStateTransition.lockedOutPoint = '&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&';
-
-      const result = await validateIdentityTopUpTransitionStructure(
-        rawStateTransition,
-      );
-
-      expectJsonSchemaError(result);
-
-      const [error] = result.getErrors();
-
-      expect(error.keyword).to.equal('pattern');
+      expect(error.keyword).to.equal('maxBytesLength');
       expect(error.dataPath).to.equal('.lockedOutPoint');
     });
   });
-
 
   describe('identityId', () => {
     it('should be present', async () => {
@@ -214,8 +197,8 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       expect(error.params.missingProperty).to.equal('identityId');
     });
 
-    it('should be a binary (encoded string)', async () => {
-      rawStateTransition.identityId = 1;
+    it('should be a byte array', async () => {
+      rawStateTransition.identityId = {};
 
       const result = await validateIdentityTopUpTransitionStructure(
         rawStateTransition,
@@ -226,12 +209,11 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.identityId');
-      expect(error.keyword).to.equal('type');
-      expect(error.params.type).to.equal('string');
+      expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should be no less than 42 chars', async () => {
-      rawStateTransition.identityId = '1'.repeat(41);
+    it('should be no less than 32 bytes', async () => {
+      rawStateTransition.identityId = Buffer.alloc(31);
 
       const result = await validateIdentityTopUpTransitionStructure(
         rawStateTransition,
@@ -242,11 +224,11 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.identityId');
-      expect(error.keyword).to.equal('minLength');
+      expect(error.keyword).to.equal('minBytesLength');
     });
 
-    it('should be no longer than 44 chars', async () => {
-      rawStateTransition.identityId = '1'.repeat(45);
+    it('should be no longer than 32 bytes', async () => {
+      rawStateTransition.identityId = Buffer.alloc(33);
 
       const result = await validateIdentityTopUpTransitionStructure(
         rawStateTransition,
@@ -257,22 +239,7 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.identityId');
-      expect(error.keyword).to.equal('maxLength');
-    });
-
-    it('should be base58 encoded', async () => {
-      rawStateTransition.identityId = '&'.repeat(44);
-
-      const result = await validateIdentityTopUpTransitionStructure(
-        rawStateTransition,
-      );
-
-      expectJsonSchemaError(result);
-
-      const [error] = result.getErrors();
-
-      expect(error.keyword).to.equal('pattern');
-      expect(error.dataPath).to.equal('.identityId');
+      expect(error.keyword).to.equal('maxBytesLength');
     });
   });
 
@@ -291,8 +258,8 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       expect(error.params.missingProperty).to.equal('signature');
     });
 
-    it('should be a binary (encoded string)', async () => {
-      rawStateTransition.signature = 1;
+    it('should be a byte array', async () => {
+      rawStateTransition.signature = {};
 
       const result = await validateIdentityTopUpTransitionStructure(rawStateTransition);
 
@@ -301,12 +268,11 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.signature');
-      expect(error.keyword).to.equal('type');
-      expect(error.params.type).to.equal('string');
+      expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should have length of 65 bytes (87 chars)', async () => {
-      rawStateTransition.signature = Buffer.alloc(10);
+    it('should be not shorter than 65 bytes', async () => {
+      rawStateTransition.signature = Buffer.alloc(64);
 
       const result = await validateIdentityTopUpTransitionStructure(rawStateTransition);
 
@@ -315,12 +281,11 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.signature');
-      expect(error.keyword).to.equal('minLength');
-      expect(error.params.limit).to.equal(87);
+      expect(error.keyword).to.equal('minBytesLength');
     });
 
-    it('should be base64 encoded', async () => {
-      rawStateTransition.signature = '&'.repeat(87);
+    it('should be not longer than 65 bytes', async () => {
+      rawStateTransition.signature = Buffer.alloc(66);
 
       const result = await validateIdentityTopUpTransitionStructure(rawStateTransition);
 
@@ -329,7 +294,7 @@ describe('validateIdentityTopUpTransitionStructureFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.signature');
-      expect(error.keyword).to.equal('pattern');
+      expect(error.keyword).to.equal('maxBytesLength');
     });
   });
 

--- a/test/integration/identity/validation/validateIdentityFactory.spec.js
+++ b/test/integration/identity/validation/validateIdentityFactory.spec.js
@@ -1,4 +1,4 @@
-const Ajv = require('ajv');
+const createAjv = require('../../../../lib/ajv/createAjv');
 
 const getIdentityFixture = require('../../../../lib/test/fixtures/getIdentityFixture');
 
@@ -27,7 +27,7 @@ describe('validateIdentityFactory', () => {
   let validatePublicKeysMock;
 
   beforeEach(function beforeEach() {
-    const schemaValidator = new JsonSchemaValidator(new Ajv());
+    const schemaValidator = new JsonSchemaValidator(createAjv());
 
     validatePublicKeysMock = this.sinonSandbox.stub().returns(new ValidationResult());
 
@@ -58,8 +58,8 @@ describe('validateIdentityFactory', () => {
       expect(validatePublicKeysMock).to.not.be.called();
     });
 
-    it('should be a string', () => {
-      rawIdentity.id = 1;
+    it('should be a byte array', () => {
+      rawIdentity.id = {};
 
       const result = validateIdentity(rawIdentity);
 
@@ -68,13 +68,13 @@ describe('validateIdentityFactory', () => {
       const [error] = result.getErrors();
 
       expect(error.dataPath).to.equal('.id');
-      expect(error.keyword).to.equal('type');
+      expect(error.keyword).to.equal('byteArray');
 
       expect(validatePublicKeysMock).to.not.be.called();
     });
 
-    it('should not be less than 42 characters', () => {
-      rawIdentity.id = '1'.repeat(41);
+    it('should not be less than 32 bytes', () => {
+      rawIdentity.id = Buffer.alloc(31);
 
       const result = validateIdentity(rawIdentity);
 
@@ -82,14 +82,14 @@ describe('validateIdentityFactory', () => {
 
       const [error] = result.getErrors();
 
-      expect(error.keyword).to.equal('minLength');
+      expect(error.keyword).to.equal('minBytesLength');
       expect(error.dataPath).to.equal('.id');
 
       expect(validatePublicKeysMock).to.not.be.called();
     });
 
-    it('should not be more than 44 characters', () => {
-      rawIdentity.id = '1'.repeat(45);
+    it('should not be more than 32 bytes', () => {
+      rawIdentity.id = Buffer.alloc(33);
 
       const result = validateIdentity(rawIdentity);
 
@@ -97,22 +97,7 @@ describe('validateIdentityFactory', () => {
 
       const [error] = result.getErrors();
 
-      expect(error.keyword).to.equal('maxLength');
-      expect(error.dataPath).to.equal('.id');
-
-      expect(validatePublicKeysMock).to.not.be.called();
-    });
-
-    it('should be base58 encoded', () => {
-      rawIdentity.id = '&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&';
-
-      const result = validateIdentity(rawIdentity);
-
-      expectJsonSchemaError(result);
-
-      const [error] = result.getErrors();
-
-      expect(error.keyword).to.equal('pattern');
+      expect(error.keyword).to.equal('maxBytesLength');
       expect(error.dataPath).to.equal('.id');
 
       expect(validatePublicKeysMock).to.not.be.called();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Definition and validation of binary data pretty complicated and confusing due to using encoded string. In case if a user needs minLength/maxLength constraints, they should be calculated for result encoded string but not an origin byte array length. Also, during validation, it required to convert raw data to JSON data (encode Buffers to string) that adds additional complexity and slowdown the consensus eventually.

## What was done?
<!--- Describe your changes in detail -->
Use `byteArray` keyword for binary fields in protocol JSON Schemas.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
