### PR TITLE
feat!: hash methods responds with Buffer

### DIFF
--- a/lib/dataContract/DataContract.js
+++ b/lib/dataContract/DataContract.js
@@ -248,10 +248,10 @@ class DataContract {
   /**
    * Returns hex string with Data Contract hash
    *
-   * @return {string}
+   * @return {Buffer}
    */
   hash() {
-    return hash(this.toBuffer()).toString('hex');
+    return hash(this.toBuffer());
   }
 
   /**

--- a/lib/document/Document.js
+++ b/lib/document/Document.js
@@ -352,10 +352,10 @@ class Document {
   /**
    * Returns hex string with object hash
    *
-   * @return {string}
+   * @return {Buffer}
    */
   hash() {
-    return hash(this.toBuffer()).toString('hex');
+    return hash(this.toBuffer());
   }
 
   /**

--- a/lib/identity/Identity.js
+++ b/lib/identity/Identity.js
@@ -110,11 +110,10 @@ class Identity {
   }
 
   /**
-   * @return {string}
+   * @return {Buffer}
    */
   hash() {
-    return hash(this.toBuffer())
-      .toString('hex');
+    return hash(this.toBuffer());
   }
 
   /**

--- a/lib/identity/IdentityPublicKey.js
+++ b/lib/identity/IdentityPublicKey.js
@@ -86,7 +86,7 @@ class IdentityPublicKey {
   /**
    * Get original public key hash
    *
-   * @returns {string}
+   * @returns {Buffer}
    */
   hash() {
     if (!this.getData()) {
@@ -97,8 +97,7 @@ class IdentityPublicKey {
       this.getData(),
     );
 
-    return originalPublicKey.hash
-      .toString('hex');
+    return originalPublicKey.hash;
   }
 
   /**

--- a/test/unit/identity/Identity.spec.js
+++ b/test/unit/identity/Identity.spec.js
@@ -100,7 +100,6 @@ describe('Identity', () => {
   describe('#hash', () => {
     it('should return hex string of a buffer return by serialize', () => {
       const buffer = Buffer.from('someString');
-      const bufferHex = buffer.toString('hex');
 
       encodeMock.returns(buffer);
       hashMock.returns(buffer);
@@ -109,7 +108,7 @@ describe('Identity', () => {
 
       expect(encodeMock).to.have.been.calledOnceWith(identity.toObject());
       expect(hashMock).to.have.been.calledOnceWith(buffer);
-      expect(result).to.equal(bufferHex);
+      expect(result).to.equal(buffer);
     });
   });
 

--- a/test/unit/identity/IdentityPublicKey.spec.js
+++ b/test/unit/identity/IdentityPublicKey.spec.js
@@ -88,7 +88,7 @@ describe('IdentityPublicKey', () => {
 
       const result = publicKey.hash();
 
-      expect(result).to.deep.equal('24940ae1982187675fc3ad95aac68769322d95f2');
+      expect(result).to.deep.equal(Buffer.from('24940ae1982187675fc3ad95aac68769322d95f2', 'hex'));
     });
 
     it('should throw invalid argument error if data was not originally provided', () => {

--- a/test/unit/identity/stateTransitions/identityCreateTransition/validateIdentityPublicKeyUniquenessFactory.spec.js
+++ b/test/unit/identity/stateTransitions/identityCreateTransition/validateIdentityPublicKeyUniquenessFactory.spec.js
@@ -45,7 +45,7 @@ describe('validateIdentityPublicKeyUniquenessFactory', () => {
 
     const [error] = result.getErrors();
 
-    expect(error.getPublicKeyHash()).to.equal(identity.getPublicKeyById(0).hash());
+    expect(error.getPublicKeyHash()).to.deep.equal(identity.getPublicKeyById(0).hash());
   });
 
   it('should return valid result if no identity id was not found', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to hashes of data models without converting them to Buffer in many places that now accept buffers for binary data.

## What was done?
<!--- Describe your changes in detail -->
`hash` methods of models respond with `Buffer`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`hash` methods respond with `Buffer`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
