### PR TITLE
fix: wrong entropy size

### DIFF
--- a/schema/dataContract/stateTransition/dataContractCreate.json
+++ b/schema/dataContract/stateTransition/dataContractCreate.json
@@ -17,8 +17,8 @@
     "entropy": {
       "type": "object",
       "byteArray": true,
-      "minBytesLength": 20,
-      "maxBytesLength": 35
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "signaturePublicKeyId": {
       "type": "integer",

--- a/schema/document/stateTransition/documentTransition/create.json
+++ b/schema/document/stateTransition/documentTransition/create.json
@@ -5,8 +5,8 @@
     "$entropy": {
       "type": "object",
       "byteArray": true,
-      "minBytesLength": 20,
-      "maxBytesLength": 35
+      "minBytesLength": 32,
+      "maxBytesLength": 32
     },
     "$createdAt": {
       "type": "integer",

--- a/test/integration/dataContract/stateTransition/validation/validateDataContractCreateTransitionStructureFactory.spec.js
+++ b/test/integration/dataContract/stateTransition/validation/validateDataContractCreateTransitionStructureFactory.spec.js
@@ -268,8 +268,8 @@ describe('validateDataContractCreateTransitionStructureFactory', () => {
       expect(error.keyword).to.equal('byteArray');
     });
 
-    it('should be no less than 20 bytes', async () => {
-      rawStateTransition.entropy = Buffer.alloc(19);
+    it('should be no less than 32 bytes', async () => {
+      rawStateTransition.entropy = Buffer.alloc(31);
 
       const result = await validateDataContractCreateTransitionStructure(rawStateTransition);
 
@@ -279,11 +279,11 @@ describe('validateDataContractCreateTransitionStructureFactory', () => {
 
       expect(error.dataPath).to.equal('.entropy');
       expect(error.keyword).to.equal('minBytesLength');
-      expect(error.params.limit).to.equal(20);
+      expect(error.params.limit).to.equal(32);
     });
 
-    it('should be no longer than 35 bytes', async () => {
-      rawStateTransition.entropy = Buffer.alloc(36);
+    it('should be no longer than 32 bytes', async () => {
+      rawStateTransition.entropy = Buffer.alloc(33);
 
       const result = await validateDataContractCreateTransitionStructure(rawStateTransition);
 
@@ -293,7 +293,7 @@ describe('validateDataContractCreateTransitionStructureFactory', () => {
 
       expect(error.dataPath).to.equal('.entropy');
       expect(error.keyword).to.equal('maxBytesLength');
-      expect(error.params.limit).to.equal(35);
+      expect(error.params.limit).to.equal(32);
     });
   });
 

--- a/test/integration/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.spec.js
+++ b/test/integration/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.spec.js
@@ -394,10 +394,10 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
           expect(error.keyword).to.equal('type');
         });
 
-        it('should be no less than 20 bytes', async () => {
+        it('should be no less than 32 bytes', async () => {
           const [documentTransition] = rawStateTransition.transitions;
 
-          documentTransition.$id = Buffer.alloc(19);
+          documentTransition.$id = Buffer.alloc(31);
 
           const result = await validateDocumentsBatchTransitionStructure(rawStateTransition);
 
@@ -407,12 +407,13 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
 
           expect(error.dataPath).to.equal('.$id');
           expect(error.keyword).to.equal('minBytesLength');
+          expect(error.params.limit).to.equal(32);
         });
 
-        it('should be no longer than 35 bytes', async () => {
+        it('should be no longer than 32 bytes', async () => {
           const [documentTransition] = rawStateTransition.transitions;
 
-          documentTransition.$id = Buffer.alloc(36);
+          documentTransition.$id = Buffer.alloc(33);
 
           const result = await validateDocumentsBatchTransitionStructure(rawStateTransition);
 
@@ -422,6 +423,7 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
 
           expect(error.dataPath).to.equal('.$id');
           expect(error.keyword).to.equal('maxBytesLength');
+          expect(error.params.limit).to.equal(32);
         });
 
         it('should no have duplicate IDs in the state transition', async () => {
@@ -696,10 +698,10 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
             expect(error.keyword).to.equal('byteArray');
           });
 
-          it('should be no less than 20 bytes', async () => {
+          it('should be no less than 32 bytes', async () => {
             const [documentTransition] = rawStateTransition.transitions;
 
-            documentTransition.$entropy = Buffer.alloc(19);
+            documentTransition.$entropy = Buffer.alloc(31);
 
             const result = await validateDocumentsBatchTransitionStructure(rawStateTransition);
 
@@ -709,12 +711,13 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
 
             expect(error.dataPath).to.equal('.$entropy');
             expect(error.keyword).to.equal('minBytesLength');
+            expect(error.params.limit).to.equal(32);
           });
 
-          it('should be no longer than 35 bytes', async () => {
+          it('should be no longer than 32 bytes', async () => {
             const [documentTransition] = rawStateTransition.transitions;
 
-            documentTransition.$entropy = Buffer.alloc(36);
+            documentTransition.$entropy = Buffer.alloc(33);
 
             const result = await validateDocumentsBatchTransitionStructure(rawStateTransition);
 
@@ -724,6 +727,7 @@ describe('validateDocumentsBatchTransitionStructureFactory', () => {
 
             expect(error.dataPath).to.equal('.$entropy');
             expect(error.keyword).to.equal('maxBytesLength');
+            expect(error.params.limit).to.equal(32);
           });
         });
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Entropy size in schemas is 20 to 35 instead of 32

## What was done?
<!--- Describe your changes in detail -->
Fixed schema to set entropy size to 32 bytes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
