### PR TITLE
fix: one ID prefix for all enriched contracts

### DIFF
--- a/lib/dataContract/enrichDataContractWithBaseSchema.js
+++ b/lib/dataContract/enrichDataContractWithBaseSchema.js
@@ -64,7 +64,8 @@ function enrichDataContractWithBaseSchema(
 }
 
 enrichDataContractWithBaseSchema.PREFIX_BYTE_0 = 0;
-enrichDataContractWithBaseSchema.PREFIX_BYTE_1 = 0;
-enrichDataContractWithBaseSchema.PREFIX_BYTE_2 = 0;
+enrichDataContractWithBaseSchema.PREFIX_BYTE_1 = 1;
+enrichDataContractWithBaseSchema.PREFIX_BYTE_2 = 2;
+enrichDataContractWithBaseSchema.PREFIX_BYTE_3 = 3;
 
 module.exports = enrichDataContractWithBaseSchema;

--- a/lib/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.js
+++ b/lib/document/stateTransition/validation/structure/validateDocumentsBatchTransitionStructureFactory.js
@@ -62,18 +62,19 @@ function validateDocumentsBatchTransitionStructureFactory(
     const enrichedBaseDataContract = enrichDataContractWithBaseSchema(
       dataContract,
       baseTransitionSchema,
+      enrichDataContractWithBaseSchema.PREFIX_BYTE_1,
     );
 
     const enrichedDataContractsByActions = {
       [ACTIONS.CREATE]: enrichDataContractWithBaseSchema(
         enrichedBaseDataContract,
         createTransitionSchema,
-        enrichDataContractWithBaseSchema.PREFIX_BYTE_1,
+        enrichDataContractWithBaseSchema.PREFIX_BYTE_2,
       ),
       [ACTIONS.REPLACE]: enrichDataContractWithBaseSchema(
         enrichedBaseDataContract,
         replaceTransitionSchema,
-        enrichDataContractWithBaseSchema.PREFIX_BYTE_2,
+        enrichDataContractWithBaseSchema.PREFIX_BYTE_3,
         ['$createdAt'],
       ),
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The same ID prefix is used for different enriched schemas so due to Ajv cache the first enriched contract is used for all cases.

## What was done?
<!--- Describe your changes in detail -->
- Passed prefix for base data contract schema
- Set different bytes for different prefixes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
