### PR TITLE
feat: get modified data ids from state transitions

### DIFF
--- a/lib/dataContract/stateTransition/DataContractCreateTransition.js
+++ b/lib/dataContract/stateTransition/DataContractCreateTransition.js
@@ -101,6 +101,15 @@ class DataContractCreateTransition extends AbstractStateTransitionIdentitySigned
   getOwnerId() {
     return this.getDataContract().getOwnerId();
   }
+
+  /**
+   * Returns id of the created contract
+   *
+   * @return {Identifier[]}
+   */
+  getModifiedDataIds() {
+    return [this.getDataContract().getId()];
+  }
 }
 
 /**

--- a/lib/document/stateTransition/DocumentsBatchTransition.js
+++ b/lib/document/stateTransition/DocumentsBatchTransition.js
@@ -115,6 +115,15 @@ class DocumentsBatchTransition extends AbstractStateTransitionIdentitySigned {
 
     return jsonStateTransition;
   }
+
+  /**
+   * Returns ids of all affected documents
+   *
+   * @return {Identifier[]}
+   */
+  getModifiedDataIds() {
+    return this.getTransitions().map((documentTransition) => documentTransition.getId());
+  }
 }
 
 /**

--- a/lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.js
+++ b/lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.js
@@ -140,6 +140,15 @@ class IdentityCreateTransition extends AbstractStateTransition {
       publicKeys: this.getPublicKeys().map((publicKey) => publicKey.toJSON()),
     };
   }
+
+  /**
+   * Returns ids of created identities
+   *
+   * @return {Identifier[]}
+   */
+  getModifiedDataIds() {
+    return [this.getIdentityId()];
+  }
 }
 
 /**

--- a/lib/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.js
+++ b/lib/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.js
@@ -120,6 +120,15 @@ class IdentityTopUpTransition extends AbstractStateTransition {
       assetLock: this.getAssetLock().toJSON(),
     };
   }
+
+  /**
+   * Returns ids of topped up identities
+   *
+   * @return {Identifier[]}
+   */
+  getModifiedDataIds() {
+    return [this.getIdentityId()];
+  }
 }
 
 /**

--- a/lib/stateTransition/AbstractStateTransition.js
+++ b/lib/stateTransition/AbstractStateTransition.js
@@ -8,6 +8,8 @@ const StateTransitionIsNotSignedError = require(
   './errors/StateTransitionIsNotSignedError',
 );
 
+const stateTransitionTypes = require('./stateTransitionTypes');
+
 const hash = require('../util/hash');
 const { encode } = require('../util/serializer');
 
@@ -44,6 +46,8 @@ class AbstractStateTransition {
 
   /**
    * @abstract
+   *
+   * @return {number}
    */
   getType() {
     throw new Error('Not implemented');
@@ -186,6 +190,43 @@ class AbstractStateTransition {
   calculateFee() {
     return calculateStateTransitionFee(this);
   }
+
+  /**
+   * Returns ids of entities affected by the state transition
+   * @abstract
+   *
+   * @return {Identifier[]}
+   */
+  getModifiedDataIds() {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns true if this state transition affects documents: create, update and delete transitions
+   *
+   * @return {boolean}
+   */
+  isDocumentStateTransition() {
+    return AbstractStateTransition.documentTransitionTypes.includes(this.getType());
+  }
+
+  /**
+   * Returns true if this state transition affects data contracts
+   *
+   * @return {boolean}
+   */
+  isDataContractStateTransition() {
+    return AbstractStateTransition.dataContractTransitionTypes.includes(this.getType());
+  }
+
+  /**
+   * Returns true if this state transition affects identities: create, update or top up.
+   *
+   * @return {boolean}
+   */
+  isIdentityStateTransition() {
+    return AbstractStateTransition.identityTransitionTypes.includes(this.getType());
+  }
 }
 
 /**
@@ -201,5 +242,16 @@ class AbstractStateTransition {
  * @property {number} type
  * @property {string} [signature]
  */
+
+AbstractStateTransition.documentTransitionTypes = [
+  stateTransitionTypes.DOCUMENTS_BATCH,
+];
+AbstractStateTransition.identityTransitionTypes = [
+  stateTransitionTypes.IDENTITY_CREATE,
+  stateTransitionTypes.IDENTITY_TOP_UP,
+];
+AbstractStateTransition.dataContractTransitionTypes = [
+  stateTransitionTypes.DATA_CONTRACT_CREATE,
+];
 
 module.exports = AbstractStateTransition;

--- a/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
+++ b/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
@@ -121,4 +121,22 @@ describe('DataContractCreateTransition', () => {
       expect(contractId).to.be.deep.equal(dataContract.getId());
     });
   });
+
+  describe('#isDataContractStateTransition', () => {
+    it('should return true', () => {
+      expect(stateTransition.isDataContractStateTransition()).to.be.true();
+    });
+  });
+
+  describe('#isDocumentStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDocumentStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isIdentityStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isIdentityStateTransition()).to.be.false();
+    });
+  });
 });

--- a/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
+++ b/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
@@ -3,6 +3,7 @@ const rewiremock = require('rewiremock/node');
 const getDataContractFixture = require('../../../../lib/test/fixtures/getDataContractFixture');
 const stateTransitionTypes = require('../../../../lib/stateTransition/stateTransitionTypes');
 
+const Identifier = require('../../../../lib/identifier/Identifier');
 const DataContract = require('../../../../lib/dataContract/DataContract');
 
 describe('DataContractCreateTransition', () => {
@@ -106,6 +107,18 @@ describe('DataContractCreateTransition', () => {
       const result = stateTransition.getOwnerId();
 
       expect(result).to.equal(stateTransition.getDataContract().getOwnerId());
+    });
+  });
+
+  describe('#getModifiedDataIds', () => {
+    it('should return ids of affected data contracts', () => {
+      const result = stateTransition.getModifiedDataIds();
+
+      expect(result.length).to.be.equal(1);
+      const contractId = result[0];
+
+      expect(contractId).to.be.an.instanceOf(Identifier);
+      expect(contractId).to.be.deep.equal(dataContract.getId());
     });
   });
 });

--- a/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
+++ b/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
@@ -128,4 +128,22 @@ describe('DocumentsBatchTransition', () => {
       expect(result).to.be.deep.equal(expectedIds);
     });
   });
+
+  describe('#isDataContractStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDataContractStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isDocumentStateTransition', () => {
+    it('should return true', () => {
+      expect(stateTransition.isDocumentStateTransition()).to.be.true();
+    });
+  });
+
+  describe('#isIdentityStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isIdentityStateTransition()).to.be.false();
+    });
+  });
 });

--- a/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
+++ b/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
@@ -118,4 +118,14 @@ describe('DocumentsBatchTransition', () => {
       expect(result).to.deep.equal(getDocumentsFixture.ownerId);
     });
   });
+
+  describe('#getModifiedDataIds', () => {
+    it('should return ids of affected documents', () => {
+      const expectedIds = documents.map((doc) => doc.getId());
+      const result = stateTransition.getModifiedDataIds();
+
+      expect(result.length).to.be.equal(10);
+      expect(result).to.be.deep.equal(expectedIds);
+    });
+  });
 });

--- a/test/unit/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.spec.js
+++ b/test/unit/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.spec.js
@@ -5,7 +5,9 @@ const stateTransitionTypes = require(
 );
 
 const Identity = require('../../../../../lib/identity/Identity');
+const IdentityCreateTransition = require('../../../../../lib/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition');
 const AssetLock = require('../../../../../lib/identity/stateTransitions/assetLock/AssetLock');
+const Identifier = require('../../../../../lib/identifier/Identifier');
 
 const getIdentityCreateTransitionFixture = require('../../../../../lib/test/fixtures/getIdentityCreateTransitionFixture');
 
@@ -154,6 +156,20 @@ describe('IdentityCreateTransition', () => {
         publicKeys: stateTransition.getPublicKeys().map((k) => k.toJSON()),
         signature: undefined,
       });
+    });
+  });
+
+  describe('#getModifiedDataIds', () => {
+    it('should return ids of created identities', () => {
+      const result = stateTransition.getModifiedDataIds();
+
+      expect(result.length).to.be.equal(1);
+      const identityId = result[0];
+
+      expect(identityId).to.be.an.instanceOf(Identifier);
+      expect(identityId).to.be.deep.equal(
+        new IdentityCreateTransition(rawStateTransition).getIdentityId(),
+      );
     });
   });
 });

--- a/test/unit/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.spec.js
+++ b/test/unit/identity/stateTransitions/identityCreateTransition/IdentityCreateTransition.spec.js
@@ -172,4 +172,22 @@ describe('IdentityCreateTransition', () => {
       );
     });
   });
+
+  describe('#isDataContractStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDataContractStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isDocumentStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDocumentStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isIdentityStateTransition', () => {
+    it('should return true', () => {
+      expect(stateTransition.isIdentityStateTransition()).to.be.true();
+    });
+  });
 });

--- a/test/unit/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.spec.js
+++ b/test/unit/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.spec.js
@@ -109,4 +109,16 @@ describe('IdentityTopUpTransition', () => {
       });
     });
   });
+
+  describe('#getModifiedDataIds', () => {
+    it('should return ids of topped up identity', () => {
+      const result = stateTransition.getModifiedDataIds();
+
+      expect(result.length).to.be.equal(1);
+      const identityId = result[0];
+
+      expect(identityId).to.be.an.instanceOf(Identifier);
+      expect(identityId).to.be.deep.equal(rawStateTransition.identityId);
+    });
+  });
 });

--- a/test/unit/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.spec.js
+++ b/test/unit/identity/stateTransitions/identityTopUpTransition/IdentityTopUpTransition.spec.js
@@ -121,4 +121,22 @@ describe('IdentityTopUpTransition', () => {
       expect(identityId).to.be.deep.equal(rawStateTransition.identityId);
     });
   });
+
+  describe('#isDataContractStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDataContractStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isDocumentStateTransition', () => {
+    it('should return false', () => {
+      expect(stateTransition.isDocumentStateTransition()).to.be.false();
+    });
+  });
+
+  describe('#isIdentityStateTransition', () => {
+    it('should return true', () => {
+      expect(stateTransition.isIdentityStateTransition()).to.be.true();
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added `getModifiedDataIds` methods to every state transition for the DAPI's SubscribeToStateTransitionResults endpoint.

## What was done?
<!--- Describe your changes in detail -->
- Added `getModifiedDataIds` to the `AbstractStateTransition` and all classes that extend it;
- Added `isDocumentStateTransition`, `isDocumentStateTransition` and `isDocumentStateTransition` to the `AbstractStateTransition`
- Added unit tests for the aforementioned methods

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through newly added unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
