### PR TITLE
feat: use `verifyInstantLock` instead of `fetchSMLStore`

### DIFF
--- a/lib/DashPlatformProtocol.js
+++ b/lib/DashPlatformProtocol.js
@@ -16,7 +16,6 @@ class DashPlatformProtocol {
    * @param {Object} options
    * @param {StateRepository} [options.stateRepository]
    * @param {JsonSchemaValidator} [options.jsonSchemaValidator]
-   * @param {boolean} [options.identities.skipAssetLockProofSignatureVerification=false]
    */
   constructor(options = {}) {
     this.stateRepository = options.stateRepository;
@@ -28,17 +27,13 @@ class DashPlatformProtocol {
       this.jsonSchemaValidator = new JsonSchemaValidator(ajv);
     }
 
-    const skipAssetLockProofSignatureVerification = options.identities
-      ? options.identities.skipAssetLockProofSignatureVerification : false;
-
-    this.initializeFacades(skipAssetLockProofSignatureVerification);
+    this.initializeFacades();
   }
 
   /**
    * @private
-   * @param {boolean} skipAssetLockProofSignatureVerification
    */
-  initializeFacades(skipAssetLockProofSignatureVerification) {
+  initializeFacades() {
     this.dataContract = new DataContractFacade(
       this.jsonSchemaValidator,
     );
@@ -51,7 +46,6 @@ class DashPlatformProtocol {
     this.stateTransition = new StateTransitionFacade(
       this.stateRepository,
       this.jsonSchemaValidator,
-      skipAssetLockProofSignatureVerification,
     );
 
     this.identity = new IdentityFacade(

--- a/lib/StateRepositoryInterface.js
+++ b/lib/StateRepositoryInterface.js
@@ -121,12 +121,12 @@
  */
 
 /**
- * Fetch Simplified Masternode List Store
+ * Verify Instant Lock
  *
  * @async
  * @method
- * @name StateRepository#fetchSMLStore
- * @returns {Promise<SimplifiedMNListStore>}
+ * @name StateRepository#verifyInstantLock
+ * @returns {Promise<boolean>}
  */
 
 /**

--- a/lib/identity/stateTransitions/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.js
+++ b/lib/identity/stateTransitions/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.js
@@ -10,13 +10,11 @@ const InvalidIdentityAssetLockProofSignatureError = require('../../../../../erro
 /**
  * @param {JsonSchemaValidator} jsonSchemaValidator
  * @param {StateRepository} stateRepository
- * @param {boolean} skipAssetLockProofSignatureVerification
  * @returns {validateInstantAssetLockProofStructure}
  */
 function validateInstantAssetLockProofStructureFactory(
   jsonSchemaValidator,
   stateRepository,
-  skipAssetLockProofSignatureVerification,
 ) {
   /**
    * @typedef {validateInstantAssetLockProofStructure}
@@ -53,10 +51,8 @@ function validateInstantAssetLockProofStructureFactory(
       return result;
     }
 
-    if (!skipAssetLockProofSignatureVerification) {
-      if (!await stateRepository.verifyInstantLock(instantLock)) {
-        result.addError(new InvalidIdentityAssetLockProofSignatureError());
-      }
+    if (!await stateRepository.verifyInstantLock(instantLock)) {
+      result.addError(new InvalidIdentityAssetLockProofSignatureError());
     }
 
     return result;

--- a/lib/identity/stateTransitions/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.js
+++ b/lib/identity/stateTransitions/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.js
@@ -54,9 +54,7 @@ function validateInstantAssetLockProofStructureFactory(
     }
 
     if (!skipAssetLockProofSignatureVerification) {
-      const smlStore = await stateRepository.fetchSMLStore();
-
-      if (!await instantLock.verify(smlStore)) {
+      if (!await stateRepository.verifyInstantLock(instantLock)) {
         result.addError(new InvalidIdentityAssetLockProofSignatureError());
       }
     }

--- a/lib/stateTransition/StateTransitionFacade.js
+++ b/lib/stateTransition/StateTransitionFacade.js
@@ -66,9 +66,8 @@ class StateTransitionFacade {
   /**
    * @param {StateRepository} stateRepository
    * @param {JsonSchemaValidator} validator
-   * @param {boolean} skipAssetLockProofSignatureVerification
    */
-  constructor(stateRepository, validator, skipAssetLockProofSignatureVerification) {
+  constructor(stateRepository, validator) {
     this.stateRepository = stateRepository;
     this.validator = validator;
 
@@ -111,7 +110,6 @@ class StateTransitionFacade {
     const validateInstantAssetLockProofStructure = validateInstantAssetLockProofStructureFactory(
       validator,
       stateRepository,
-      skipAssetLockProofSignatureVerification,
     );
 
     const proofValidationFunctionsByType = {

--- a/lib/test/mocks/createStateRepositoryMock.js
+++ b/lib/test/mocks/createStateRepositoryMock.js
@@ -9,7 +9,7 @@
  *   fetchTransaction: *,
  *   fetchIdentity: *,
  *   storeIdentity: *,
- *   fetchSMLStore: *,
+ *   verifyInstantLock: *,
  * }}
  */
 module.exports = function createStateRepositoryMock(sinonSandbox) {
@@ -25,7 +25,7 @@ module.exports = function createStateRepositoryMock(sinonSandbox) {
     fetchLatestPlatformBlockHeader: sinonSandbox.stub(),
     storeIdentityPublicKeyHashes: sinonSandbox.stub(),
     fetchIdentityIdsByPublicKeyHashes: sinonSandbox.stub(),
-    fetchSMLStore: sinonSandbox.stub(),
+    verifyInstantLock: sinonSandbox.stub(),
     storeAssetLockTransactionOutPoint: sinonSandbox.stub(),
     checkAssetLockTransactionOutPointExists: sinonSandbox.stub(),
   };

--- a/test/integration/identity/stateTransition/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.spec.js
+++ b/test/integration/identity/stateTransition/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.spec.js
@@ -22,7 +22,6 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
   let InstantLockClassMock;
   let instantLockMock;
   let validateInstantAssetLockProofStructure;
-  let smlStore;
   let jsonSchemaValidator;
   let validateInstantAssetLockProofStructureFactory;
 
@@ -37,9 +36,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
 
     stateRepositoryMock = createStateRepositoryMock(this.sinonSandbox);
 
-    smlStore = {};
-
-    stateRepositoryMock.fetchSMLStore.resolves(smlStore);
+    stateRepositoryMock.verifyInstantLock.resolves(true);
 
     instantLockMock = {
       txid: assetLock.getTransaction().id,
@@ -82,7 +79,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       expect(error.keyword).to.equal('required');
       expect(error.params.missingProperty).to.equal('type');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -98,7 +95,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       expect(error.dataPath).to.equal('.type');
       expect(error.keyword).to.equal('const');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
   });
@@ -117,7 +114,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       expect(error.keyword).to.equal('required');
       expect(error.params.missingProperty).to.equal('instantLock');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -135,7 +132,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
 
       expect(byteArrayError.keyword).to.equal('byteArray');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -151,7 +148,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       expect(error.dataPath).to.equal('.instantLock');
       expect(error.keyword).to.equal('minItems');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -167,7 +164,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       expect(error.dataPath).to.equal('.instantLock');
       expect(error.keyword).to.equal('maxItems');
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -186,7 +183,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
 
       expect(error.message).to.equal(`Invalid asset lock proof: ${instantLockError.message}`);
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
@@ -197,19 +194,18 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
 
       expectValidationError(result, IdentityAssetLockProofMismatchError);
 
-      expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+      expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
       expect(instantLockMock.verify).to.not.be.called();
     });
 
     it('should have valid signature', async () => {
-      instantLockMock.verify.resolves(false);
+      stateRepositoryMock.verifyInstantLock.resolves(false);
 
       const result = await validateInstantAssetLockProofStructure(rawProof, transaction);
 
       expectValidationError(result, InvalidIdentityAssetLockProofSignatureError);
 
-      expect(stateRepositoryMock.fetchSMLStore).to.be.calledOnceWithExactly();
-      expect(instantLockMock.verify).to.be.calledOnceWithExactly(smlStore);
+      expect(stateRepositoryMock.verifyInstantLock).to.be.calledOnce();
     });
   });
 
@@ -227,7 +223,7 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
     expect(result).to.be.an.instanceOf(ValidationResult);
     expect(result.isValid()).to.be.true();
 
-    expect(stateRepositoryMock.fetchSMLStore).to.not.be.called();
+    expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
     expect(instantLockMock.verify).to.not.be.called();
   });
 
@@ -237,7 +233,6 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
     expect(result).to.be.an.instanceOf(ValidationResult);
     expect(result.isValid()).to.be.true();
 
-    expect(stateRepositoryMock.fetchSMLStore).to.be.calledOnceWithExactly();
-    expect(instantLockMock.verify).to.be.calledOnceWithExactly(smlStore);
+    expect(stateRepositoryMock.verifyInstantLock).to.be.calledOnce();
   });
 });

--- a/test/integration/identity/stateTransition/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.spec.js
+++ b/test/integration/identity/stateTransition/assetLock/proof/instant/validateInstantAssetLockProofStructureFactory.spec.js
@@ -56,12 +56,9 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
       },
     );
 
-    const skipAssetLockProofSignatureVerification = false;
-
     validateInstantAssetLockProofStructure = validateInstantAssetLockProofStructureFactory(
       jsonSchemaValidator,
       stateRepositoryMock,
-      skipAssetLockProofSignatureVerification,
     );
   });
 
@@ -207,24 +204,6 @@ describe('validateInstantAssetLockProofStructureFactory', () => {
 
       expect(stateRepositoryMock.verifyInstantLock).to.be.calledOnce();
     });
-  });
-
-  it('should skip signature verification if skipAssetLockProofSignatureVerification passed', async () => {
-    const skipAssetLockProofSignatureVerification = true;
-
-    validateInstantAssetLockProofStructure = validateInstantAssetLockProofStructureFactory(
-      jsonSchemaValidator,
-      stateRepositoryMock,
-      skipAssetLockProofSignatureVerification,
-    );
-
-    const result = await validateInstantAssetLockProofStructure(rawProof, transaction);
-
-    expect(result).to.be.an.instanceOf(ValidationResult);
-    expect(result.isValid()).to.be.true();
-
-    expect(stateRepositoryMock.verifyInstantLock).to.not.be.called();
-    expect(instantLockMock.verify).to.not.be.called();
   });
 
   it('should return valid result', async () => {

--- a/test/unit/DashPlatformProtocol.spec.js
+++ b/test/unit/DashPlatformProtocol.spec.js
@@ -9,19 +9,14 @@ describe('DashPlatformProtocol', () => {
   let dpp;
   let stateRepositoryMock;
   let jsonSchemaValidatorMock;
-  let skipAssetLockProofSignatureVerification;
 
   beforeEach(function beforeEach() {
     stateRepositoryMock = createStateRepositoryMock(this.sinonSandbox);
     jsonSchemaValidatorMock = {};
-    skipAssetLockProofSignatureVerification = true;
 
     dpp = new DashPlatformProtocol({
       stateRepository: stateRepositoryMock,
       jsonSchemaValidator: jsonSchemaValidatorMock,
-      identities: {
-        skipAssetLockProofSignatureVerification,
-      },
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `verifyInstantLock` method now to move things to the Drive's side

## What was done?
<!--- Describe your changes in detail -->
- Updated State Repository interface
- Updated `validateInstantAssetLockProofStructure` method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
