### PR TITLE
feat!: prepend protocol version for binary format

### DIFF
--- a/lib/document/Document.js
+++ b/lib/document/Document.js
@@ -365,7 +365,13 @@ class Document {
    * @return {Buffer}
    */
   toBuffer() {
-    return encode(this.toObject());
+    const serializedData = this.toObject();
+    delete serializedData.$protocolVersion;
+
+    const protocolVersionUInt32 = Buffer.alloc(4);
+    protocolVersionUInt32.writeUInt32BE(this.getProtocolVersion(), 0);
+
+    return Buffer.concat([protocolVersionUInt32, encode(serializedData)]);
   }
 
   /**

--- a/lib/document/DocumentFactory.js
+++ b/lib/document/DocumentFactory.js
@@ -159,7 +159,9 @@ class DocumentFactory {
   async createFromBuffer(buffer, options = { }) {
     let rawDocument;
     try {
-      rawDocument = decode(buffer);
+      // first 4 bytes are protocol version
+      rawDocument = decode(buffer.slice(4, buffer.length));
+      rawDocument.$protocolVersion = buffer.slice(0, 4).readUInt32BE(0);
     } catch (error) {
       throw new InvalidDocumentError([
         new SerializedObjectParsingError(

--- a/lib/identity/Identity.js
+++ b/lib/identity/Identity.js
@@ -108,7 +108,13 @@ class Identity {
    * @return {Buffer}
    */
   toBuffer() {
-    return encode(this.toObject());
+    const serializedData = this.toObject();
+    delete serializedData.protocolVersion;
+
+    const protocolVersionUInt32 = Buffer.alloc(4);
+    protocolVersionUInt32.writeUInt32BE(this.getProtocolVersion(), 0);
+
+    return Buffer.concat([protocolVersionUInt32, encode(serializedData)]);
   }
 
   /**

--- a/lib/identity/IdentityFactory.js
+++ b/lib/identity/IdentityFactory.js
@@ -77,7 +77,9 @@ class IdentityFactory {
   createFromBuffer(buffer, options = {}) {
     let rawIdentity;
     try {
-      rawIdentity = decode(buffer);
+      // first 4 bytes are protocol version
+      rawIdentity = decode(buffer.slice(4, buffer.length));
+      rawIdentity.protocolVersion = buffer.slice(0, 4).readUInt32BE(0);
     } catch (error) {
       throw new InvalidIdentityError([
         new SerializedObjectParsingError(

--- a/lib/stateTransition/AbstractStateTransition.js
+++ b/lib/stateTransition/AbstractStateTransition.js
@@ -129,7 +129,13 @@ class AbstractStateTransition {
    * @return {Buffer}
    */
   toBuffer(options = {}) {
-    return encode(this.toObject(options));
+    const serializedData = this.toObject(options);
+    delete serializedData.protocolVersion;
+
+    const protocolVersionUInt32 = Buffer.alloc(4);
+    protocolVersionUInt32.writeUInt32BE(this.getProtocolVersion(), 0);
+
+    return Buffer.concat([protocolVersionUInt32, encode(serializedData)]);
   }
 
   /**

--- a/lib/stateTransition/StateTransitionFactory.js
+++ b/lib/stateTransition/StateTransitionFactory.js
@@ -52,7 +52,9 @@ class StateTransitionFactory {
   async createFromBuffer(buffer, options = { }) {
     let rawStateTransition;
     try {
-      rawStateTransition = decode(buffer);
+      // first 4 bytes are protocol version
+      rawStateTransition = decode(buffer.slice(4, buffer.length));
+      rawStateTransition.protocolVersion = buffer.slice(0, 4).readUInt32BE(0);
     } catch (error) {
       throw new InvalidStateTransitionError([
         new SerializedObjectParsingError(

--- a/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
+++ b/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
@@ -69,23 +69,31 @@ describe('DataContractCreateTransition', () => {
 
   describe('#toBuffer', () => {
     it('should return serialized State Transition', () => {
-      const serializedStateTransition = '123';
+      const serializedStateTransition = Buffer.from('123');
 
       encodeMock.returns(serializedStateTransition);
 
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(stateTransition.protocolVersion, 0);
+
       const result = stateTransition.toBuffer();
 
-      expect(result).to.equal(serializedStateTransition);
+      expect(result).to.deep.equal(
+        Buffer.concat([protocolVersionUInt32, serializedStateTransition]),
+      );
+
+      const dataToEncode = stateTransition.toObject();
+      delete dataToEncode.protocolVersion;
 
       expect(encodeMock.getCall(0).args).to.have.deep.members([
-        stateTransition.toObject(),
+        dataToEncode,
       ]);
     });
   });
 
   describe('#hash', () => {
     it('should return State Transition hash as hex', () => {
-      const serializedDocument = '123';
+      const serializedDocument = Buffer.from('123');
       const hashedDocument = '456';
 
       encodeMock.returns(serializedDocument);
@@ -95,10 +103,18 @@ describe('DataContractCreateTransition', () => {
 
       expect(result).to.equal(hashedDocument);
 
+      const dataToEncode = stateTransition.toObject();
+      delete dataToEncode.protocolVersion;
+
       expect(encodeMock.getCall(0).args).to.have.deep.members([
-        stateTransition.toObject(),
+        dataToEncode,
       ]);
-      expect(hashMock).to.have.been.calledOnceWith(serializedDocument);
+
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(stateTransition.protocolVersion, 0);
+
+      expect(hashMock).to.have.been.calledOnceWith(
+        Buffer.concat([protocolVersionUInt32, serializedDocument]));
     });
   });
 

--- a/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
+++ b/test/unit/dataContract/stateTransition/DataContractCreateTransition.spec.js
@@ -114,7 +114,8 @@ describe('DataContractCreateTransition', () => {
       protocolVersionUInt32.writeUInt32BE(stateTransition.protocolVersion, 0);
 
       expect(hashMock).to.have.been.calledOnceWith(
-        Buffer.concat([protocolVersionUInt32, serializedDocument]));
+        Buffer.concat([protocolVersionUInt32, serializedDocument]),
+      );
     });
   });
 

--- a/test/unit/document/Document.spec.js
+++ b/test/unit/document/Document.spec.js
@@ -401,16 +401,22 @@ describe('Document', () => {
 
   describe('#toBuffer', () => {
     it('should return serialized Document', () => {
-      const serializedDocument = '123';
+      const serializedDocument = Buffer.from('123');
 
       encodeMock.returns(serializedDocument);
 
       const result = document.toBuffer();
 
-      expect(result).to.equal(serializedDocument);
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(rawDocument.$protocolVersion, 0);
+
+      expect(result).to.deep.equal(Buffer.concat([protocolVersionUInt32, serializedDocument]));
+
+      const documentToEncode = { ...rawDocument };
+      delete documentToEncode.$protocolVersion;
 
       expect(encodeMock.getCall(0).args).to.have.deep.members([
-        rawDocument,
+        documentToEncode,
       ]);
     });
   });

--- a/test/unit/document/DocumentFactory.spec.js
+++ b/test/unit/document/DocumentFactory.spec.js
@@ -257,7 +257,10 @@ describe('DocumentFactory', () => {
 
       expect(factory.createFromObject).to.have.been.calledOnceWith(document.toObject());
 
-      expect(decodeMock).to.have.been.calledOnceWith(serializedDocument);
+      // cut version information
+      const dataToDecode = serializedDocument.slice(4, serializedDocument.length);
+
+      expect(decodeMock).to.have.been.calledOnceWith(dataToDecode);
     });
 
     it('should throw consensus error if `decode` fails', async () => {

--- a/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
+++ b/test/unit/document/stateTransition/DocumentsBatchTransition.spec.js
@@ -82,21 +82,29 @@ describe('DocumentsBatchTransition', () => {
 
   describe('#toBuffer', () => {
     it('should return serialized Documents State Transition', () => {
-      const serializedStateTransition = '123';
+      const serializedStateTransition = Buffer.from('123');
 
       encodeMock.returns(serializedStateTransition);
 
       const result = stateTransition.toBuffer();
 
-      expect(result).to.equal(serializedStateTransition);
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(stateTransition.protocolVersion, 0);
 
-      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toObject());
+      expect(result).to.deep.equal(
+        Buffer.concat([protocolVersionUInt32, serializedStateTransition]),
+      );
+
+      const dataToEncode = stateTransition.toObject();
+      delete dataToEncode.protocolVersion;
+
+      expect(encodeMock).to.have.been.calledOnceWith(dataToEncode);
     });
   });
 
   describe('#hash', () => {
     it('should return Documents State Transition hash as hex', () => {
-      const serializedDocument = '123';
+      const serializedDocument = Buffer.from('123');
       const hashedDocument = '456';
 
       encodeMock.returns(serializedDocument);
@@ -106,8 +114,17 @@ describe('DocumentsBatchTransition', () => {
 
       expect(result).to.equal(hashedDocument);
 
-      expect(encodeMock).to.have.been.calledOnceWith(stateTransition.toObject());
-      expect(hashMock).to.have.been.calledOnceWith(serializedDocument);
+      const dataToEncode = stateTransition.toObject();
+      delete dataToEncode.protocolVersion;
+
+      expect(encodeMock).to.have.been.calledOnceWith(dataToEncode);
+
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(stateTransition.protocolVersion, 0);
+
+      expect(hashMock).to.have.been.calledOnceWith(
+        Buffer.concat([protocolVersionUInt32, serializedDocument]),
+      );
     });
   });
 

--- a/test/unit/identity/Identity.spec.js
+++ b/test/unit/identity/Identity.spec.js
@@ -96,11 +96,19 @@ describe('Identity', () => {
 
   describe('#toBuffer', () => {
     it('should return serialized Identity', () => {
-      encodeMock.returns(42); // for example
+      const encodeMockData = Buffer.from('42');
+      encodeMock.returns(encodeMockData); // for example
+
       const result = identity.toBuffer();
 
-      expect(encodeMock).to.have.been.calledOnceWith(identity.toObject());
-      expect(result).to.equal(42);
+      const identityDataToEncode = identity.toObject();
+      delete identityDataToEncode.protocolVersion;
+
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(identity.getProtocolVersion(), 0);
+
+      expect(encodeMock).to.have.been.calledOnceWith(identityDataToEncode);
+      expect(result).to.deep.equal(Buffer.concat([protocolVersionUInt32, encodeMockData]));
     });
   });
 
@@ -113,8 +121,14 @@ describe('Identity', () => {
 
       const result = identity.hash();
 
-      expect(encodeMock).to.have.been.calledOnceWith(identity.toObject());
-      expect(hashMock).to.have.been.calledOnceWith(buffer);
+      const identityDataToEncode = identity.toObject();
+      delete identityDataToEncode.protocolVersion;
+
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(identity.getProtocolVersion(), 0);
+
+      expect(encodeMock).to.have.been.calledOnceWith(identityDataToEncode);
+      expect(hashMock).to.have.been.calledOnceWith(Buffer.concat([protocolVersionUInt32, buffer]));
       expect(result).to.equal(buffer);
     });
   });

--- a/test/unit/identity/IdentityFactory.spec.js
+++ b/test/unit/identity/IdentityFactory.spec.js
@@ -130,7 +130,10 @@ describe('IdentityFactory', () => {
 
       expect(factory.createFromObject).to.have.been.calledOnceWith(identity.toObject());
 
-      expect(decodeMock).to.have.been.calledOnceWith(serializedIdentity);
+      // cut version information
+      const dataToDecode = serializedIdentity.slice(4, serializedIdentity.length);
+
+      expect(decodeMock).to.have.been.calledOnceWith(dataToDecode);
     });
 
     it('should throw consensus error if `decode` fails', () => {

--- a/test/unit/stateTransition/StateTransitionFactory.spec.js
+++ b/test/unit/stateTransition/StateTransitionFactory.spec.js
@@ -115,7 +115,10 @@ describe('StateTransitionFactory', () => {
 
       expect(factory.createFromObject).to.have.been.calledOnceWith(rawStateTransition);
 
-      expect(decodeMock).to.have.been.calledOnceWith(serializedStateTransition);
+      // cut version information
+      const dataToDecode = serializedStateTransition.slice(4, serializedStateTransition.length);
+
+      expect(decodeMock).to.have.been.calledOnceWith(dataToDecode);
     });
 
     it('should throw consensus error if `decode` fails', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Need to move protocol version information out from encoded data and prepend the binary format. This allows to change the serialization format and keep backward compatibility.

## What was done?
<!--- Describe your changes in detail -->
Modified `toBuffer` methods to encode data into new binary format.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Previously serialized data is not compatible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
