### PR TITLE
fix!: protocol version was missing from binary data for data contract

### DIFF
--- a/lib/dataContract/DataContract.js
+++ b/lib/dataContract/DataContract.js
@@ -278,7 +278,13 @@ class DataContract {
    * @returns {Buffer}
    */
   toBuffer() {
-    return encode(this.toObject());
+    const serializedData = this.toObject();
+    delete serializedData.protocolVersion;
+
+    const protocolVersionUInt32 = Buffer.alloc(4);
+    protocolVersionUInt32.writeUInt32BE(this.getProtocolVersion(), 0);
+
+    return Buffer.concat([protocolVersionUInt32, encode(serializedData)]);
   }
 
   /**

--- a/lib/dataContract/DataContractFactory.js
+++ b/lib/dataContract/DataContractFactory.js
@@ -80,7 +80,9 @@ class DataContractFactory {
   async createFromBuffer(buffer, options = { }) {
     let rawDataContract;
     try {
-      rawDataContract = decode(buffer);
+      // first 4 bytes are protocol version
+      rawDataContract = decode(buffer.slice(4, buffer.length));
+      rawDataContract.protocolVersion = buffer.slice(0, 4).readUInt32BE(0);
     } catch (error) {
       throw new InvalidDataContractError([
         new SerializedObjectParsingError(

--- a/test/unit/dataContract/DataContract.spec.js
+++ b/test/unit/dataContract/DataContract.spec.js
@@ -284,15 +284,20 @@ describe('DataContract', () => {
 
   describe('#toBuffer', () => {
     it('should return DataContract as a Buffer', () => {
-      const serializedDocument = '123';
+      const serializedDataContract = Buffer.from('123');
 
-      encodeMock.returns(serializedDocument);
+      encodeMock.returns(serializedDataContract);
 
       const result = dataContract.toBuffer();
 
-      expect(result).to.equal(serializedDocument);
+      const dataContractToEncode = dataContract.toObject();
+      delete dataContractToEncode.protocolVersion;
 
-      expect(encodeMock).to.have.been.calledOnceWith(dataContract.toObject());
+      const protocolVersionUInt32 = Buffer.alloc(4);
+      protocolVersionUInt32.writeUInt32BE(dataContract.getProtocolVersion(), 0);
+
+      expect(encodeMock).to.have.been.calledOnceWith(dataContractToEncode);
+      expect(result).to.deep.equal(Buffer.concat([protocolVersionUInt32, serializedDataContract]));
     });
   });
 

--- a/test/unit/dataContract/DataContractFactory.spec.js
+++ b/test/unit/dataContract/DataContractFactory.spec.js
@@ -142,7 +142,10 @@ describe('DataContractFactory', () => {
 
       expect(factory.createFromObject).to.have.been.calledOnceWith(rawDataContract);
 
-      expect(decodeMock).to.have.been.calledOnceWith(serializedDataContract);
+      // cut version information
+      const dataToDecode = serializedDataContract.slice(4, serializedDataContract.length);
+
+      expect(decodeMock).to.have.been.calledOnceWith(dataToDecode);
     });
 
     it('should throw consensus error if `decode` fails', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing missing `protocolVersion` that should've been prepended in `toBuffer` of `DataContract` in following PR (#325)

## What was done?
<!--- Describe your changes in detail -->
- prepend `protocolVersion ` in `toBuffer` of `DataContract`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- Previously serialized data is not compatible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
