### PR TITLE
fix: building indices on arrays using prefixItems

### DIFF
--- a/lib/dataContract/validation/validateDataContractFactory.js
+++ b/lib/dataContract/validation/validateDataContractFactory.js
@@ -189,7 +189,7 @@ module.exports = function validateDataContractFactory(
 
             if (propertyType === 'array' && !isByteArray) {
               const { items, prefixItems } = propertyDefinition;
-              if (prefixItems && prefixItems.length) {
+              if (prefixItems) {
                 if (
                   prefixItems.some((prefixItem) => prefixItem.type === 'object' || prefixItem.type === 'array')
                   || !prefixItems.every((prefixItem) => prefixItem.type === prefixItems[0].type)

--- a/lib/dataContract/validation/validateDataContractFactory.js
+++ b/lib/dataContract/validation/validateDataContractFactory.js
@@ -189,8 +189,14 @@ module.exports = function validateDataContractFactory(
 
             if (propertyType === 'array' && !isByteArray) {
               const { items, prefixItems } = propertyDefinition;
-
-              if (prefixItems || items.type === 'object' || items.type === 'array') {
+              if (prefixItems && prefixItems.length) {
+                if (
+                  prefixItems.some((prefixItem) => prefixItem.type === 'object' || prefixItem.type === 'array')
+                  || !prefixItems.every((prefixItem) => prefixItem.type === prefixItems[0].type)
+                ) {
+                  invalidPropertyType = 'array';
+                }
+              } else if (prefixItems || items.type === 'object' || items.type === 'array') {
                 invalidPropertyType = 'array';
               }
             }

--- a/lib/dataContract/validation/validateDataContractFactory.js
+++ b/lib/dataContract/validation/validateDataContractFactory.js
@@ -196,7 +196,7 @@ module.exports = function validateDataContractFactory(
                 ) {
                   invalidPropertyType = 'array';
                 }
-              } else if (prefixItems || items.type === 'object' || items.type === 'array') {
+              } else if (items.type === 'object' || items.type === 'array') {
                 invalidPropertyType = 'array';
               }
             }

--- a/lib/dataContract/validation/validateDataContractFactory.js
+++ b/lib/dataContract/validation/validateDataContractFactory.js
@@ -189,14 +189,16 @@ module.exports = function validateDataContractFactory(
 
             if (propertyType === 'array' && !isByteArray) {
               const { items, prefixItems } = propertyDefinition;
-              if (prefixItems) {
-                if (
+
+              const isInvalidPrefixItems = prefixItems
+                && (
                   prefixItems.some((prefixItem) => prefixItem.type === 'object' || prefixItem.type === 'array')
                   || !prefixItems.every((prefixItem) => prefixItem.type === prefixItems[0].type)
-                ) {
-                  invalidPropertyType = 'array';
-                }
-              } else if (items.type === 'object' || items.type === 'array') {
+                );
+
+              const isInvalidItemTypes = items.type === 'object' || items.type === 'array';
+
+              if (isInvalidPrefixItems || isInvalidItemTypes) {
                 invalidPropertyType = 'array';
               }
             }

--- a/lib/test/fixtures/getDataContractFixture.js
+++ b/lib/test/fixtures/getDataContractFixture.js
@@ -82,6 +82,30 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],
       additionalProperties: false,
     },
+    indexedArray: {
+      type: 'object',
+      indices: [
+        {
+          properties: [
+            { mentions: 'asc' },
+          ],
+        },
+      ],
+      properties: {
+        mentions: {
+          type: 'array',
+          prefixItems: [
+            {
+              type: 'string',
+            },
+          ],
+          minItems: 1,
+          maxItems: 5,
+          items: false,
+        },
+      },
+      additionalProperties: false,
+    },
     noTimeDocument: {
       type: 'object',
       properties: {

--- a/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -62,7 +62,7 @@ describe('validateDataContractFactory', function main() {
     it('should be present', async () => {
       rawDataContract = {
         documents: {
-          zalupa: {
+          someDocument: {
             type: 'object',
           },
         },
@@ -1552,6 +1552,86 @@ describe('validateDataContractFactory', function main() {
         expect(error.getPropertyType()).to.equal('array');
         expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
         expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property is an array of different types', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+          {
+            type: 'string',
+          },
+          {
+            type: 'number',
+          },
+        ];
+
+        rawDataContract.documents.indexedArray.properties.mentions.minItems = 2;
+
+        const result = await validateDataContract(rawDataContract);
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+        expect(error.getPropertyName()).to.equal('mentions');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedArray');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property contained prefixItems array of arrays', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+          {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        ];
+
+        const result = await validateDataContract(rawDataContract);
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+        expect(error.getPropertyName()).to.equal('mentions');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedArray');
+        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      });
+
+      it('should return invalid result if index property contained prefixItems array of objects', async () => {
+        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+
+        const indexDefinition = indexedDocumentDefinition.indices[0];
+
+        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+          {
+            type: 'object',
+            properties: {
+              something: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+        ];
+
+        const result = await validateDataContract(rawDataContract);
+        expectValidationError(result, InvalidIndexPropertyTypeError);
+
+        const [error] = result.getErrors();
+        expect(error.getPropertyName()).to.equal('mentions');
+        expect(error.getPropertyType()).to.equal('array');
+        expect(error.getRawDataContract()).to.deep.equal(rawDataContract);
+        expect(error.getDocumentType()).to.deep.equal('indexedArray');
         expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
       });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DPP throws an error when you try to use index on arrays using prefixItems keyword #275 

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
