### PR TITLE
docs: redirect Github page to new repo site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,43 +1,13 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>js-dpp - JavaScript implementation of the Dash Platform Protocol</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="keywords" content="dpp, dash, javascript, primitives, platform protocol, Identity, Data Contract">
-  <meta name="description" content="JavaScript implementation of the Dash Platform Protocol.">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
-</head>
-<body>
-<div id="app"></div>
-<script>
-  window.$docsify = {
-    alias: {
-      '.*?/': 'https://raw.githubusercontent.com/dashevo/js-dpp/master/README.md',
-    },
-    name: 'js-dpp',
-    repo: 'https://github.com/dashevo/js-dpp',
-    loadSidebar: "_sidebar.md",
-    maxLevel: 4,
-    subMaxLevel: 2,
-    search: {
-      noData: {
-        '/': 'No results!'
-      },
-      paths: 'auto',
-      placeholder: {
-        '/': 'Search'
-      }
-    },
-    // search: 'auto',
-    formatUpdated: '{MM}/{DD} {HH}:{mm}',
-    themeColor: '#008de4',
-    auto2top: true,
-  }
-</script>
-<script src="https://cdn.jsdelivr.net/npm/docsify@4"></script>
-<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
-</body>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=https://dashevo.github.io/platform/Dash-Platform-Protocol/Overview/" />
+        <link rel="canonical" href="https://dashevo.github.io/platform/Dash-Platform-Protocol/Overview/" />
+    </head>
+    <body>
+        <h1>
+            The page been moved to <a href="https://dashevo.github.io/platform/Dash-Platform-Protocol/Overview/">https://dashevo.github.io/platform/Dash-Platform-Protocol/Overview/</a>
+        </h1>
+    </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the introduction of the monorepo, this repo will no longer be updated. Since there are some links on various sites that direct people to the Github pages site hosted here, it would be better to redirect them to the new repo's site than to simply shutdown this one.

## What was done?
<!--- Describe your changes in detail -->
Modified the site to redirect to the [dashevo/platform](https://github.com/dashevo/platform) GH pages [site](https://dashevo.github.io/platform/).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my own fork

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
